### PR TITLE
Simplify welcome page for github docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Note: Currently Tizen/TAU specific extensions are under development.
 ## Where to get it
 * [TAU source code](https://github.com/Samsung/TAU/)
 * [TAU releases](https://github.com/Samsung/TAU/releases)
-* [latest release](https://github.com/Samsung/TAU/releases/latest)
+  * [latest release](https://github.com/Samsung/TAU/releases/latest)
 
 ## Simple usage example
 ```html

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,13 +23,13 @@ When using TAU you will get many benefits usable in your code:
 There are few simple possibilites to get started using TAU
 
 ### Using Tizen Studio
-1. Download and install (Tizen SDK)[https://developer.tizen.org/]
-2. Create Sample Web App TAU project. TAU library will be already included
+1. Download and install [Tizen SDK](https://developer.tizen.org/)
+2. Use wizard to create Sample Web App TAU project. TAU library will be already included
 
 ### Using WATT
 Note: Online WATT server is currently under preparation.
 You can find out more about WATT
-(Tizen SDK)[https://github.com/Samsung/WATT]
+[here](https://github.com/Samsung/WATT/)
 
 ### Including TAU in your source code
 ```html

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,10 @@ Note: Online WATT server is currently under preparation.
 You can find out more about WATT
 [here](https://github.com/Samsung/WATT/)
 
+### Using VSCode
+You can use [VSCode](https://code.visualstudio.com/) with set of extensions supporting web apps and TAU development.
+Note: Currently Tizen/TAU specific extensions are under development.
+
 ### Including TAU in your source code
 ```html
 <script src="../lib/tau/mobile/js/tau.js"></script>
@@ -38,6 +42,7 @@ You can find out more about WATT
 ## Where to get it
 * [TAU source code](https://github.com/Samsung/TAU/)
 * [TAU releases](https://github.com/Samsung/TAU/releases)
+* [latest release](https://github.com/Samsung/TAU/releases/latest)
 
 ## Simple usage example
 ```html

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,11 +9,8 @@ application coding.
 When using TAU you will get many benefits usable in your code:
 
 * A standalone library, meaning no additional libraries are needed
-* Can be used with jQuery, TAU exposes a special API to the jQuery object which is
-  identical to jQuery Mobile, migration is painless
 * Written with speed in mind, all of the code is tweaked for maximum performance
 * Application can be _built_ to dramatically improve startup performance
-* ECMAScript5 and HTML5 compliant
 * Large and open API, methods and core function (event utility functions) are available and not hidden to the developer
 * Customizable, easy to extend (and create new widgets)
 * Optimized for wearable, mobile and TV devices

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,17 +4,9 @@ TAU is the standard web UI library for Tizen platform. The acronym stands for Ti
 Advanced UI Library. It is a collection of UI controls called *widgets* which simplify
 application coding.
 
-## History
-
-TAU originated from Tizen Web UI Framework Library (standard library for Tizen 2.2.1),
-which was mainly based as an extension to jQuery Mobile. Key features of the former were
-coding simplification and app creation speed. With that in mind TAU was created as the
-framework *advanced to the next level*. TAU is a standalone UI library, without jQuery
-overhead, but that duo can be used as explained in this [guide later](using_jquery_with_tau.html).
-
 ## Benefits
 
-When using TAU you will get many benefits usable in your code.
+When using TAU you will get many benefits usable in your code:
 
 * A standalone library, meaning no additional libraries are needed
 * Can be used with jQuery, TAU exposes a special API to the jQuery object which is
@@ -27,8 +19,27 @@ When using TAU you will get many benefits usable in your code.
 * Optimized for wearable, mobile and TV devices
 * Supports device profiles (mobile, wearable and TV)
 
-## Simple example
+## Getting started
+There are few simple possibilites to get started using TAU
 
+### Using Tizen Studio
+1. Download and install (Tizen SDK)[https://developer.tizen.org/]
+2. Create Sample Web App TAU project. TAU library will be already included
+
+### Using WATT
+Note: Online WATT server is currently under preparation.
+You can find out more about WATT
+(Tizen SDK)[https://github.com/Samsung/WATT]
+
+### Including TAU in your source code
+```html
+<script src="../lib/tau/mobile/js/tau.js"></script>
+```
+## Where to get it
+* [TAU source code](https://github.com/Samsung/TAU/)
+* [TAU releases](https://github.com/Samsung/TAU/releases)
+
+## Simple usage example
 ```html
 <div class="ui-page ui-page-active">
   <div class="ui-header">MyApplication</div>
@@ -47,26 +58,9 @@ When using TAU you will get many benefits usable in your code.
 </script>
 ```
 
-**Warning**
+## Documentation
 
-_Examples in browsers_
-
-Some of the functionality shown in the examples may not work properly in a desktop browser, to fully get the TAU experience use a real Tizen device or Tizen emulator from the Tizen SDK.
-
-The example above shows a simple application, with a header and a button in the footer
-that closes the application. Click on the preview to check out how it works on different
-framework profiles.
-
-_Examples for profiles_
-
-TAU Profiles (mobile, TV, wearable) have differences, so some of the examples will not have preview buttons for specific profiles.
-
-## Where to get it
-
-The framework is included on all Tizen devices and the SDK emulator (starting from Tizen 2.3). Just create
-a new web application in the Tizen SDK IDE. See also our [documentation](https://developer.tizen.org/dev-guide/5.0.0/org.tizen.web.apireference/html/ui_fw_api/ui_fw_api_cover.htm) and [github repository](https://github.com/Samsung/TAU).
-
-## What next?
+* [TAU API Reference](https://developer.tizen.org/dev-guide/5.0.0/org.tizen.web.apireference/html/ui_fw_api/ui_fw_api_cover.htm)
 
 If you are new to the whole standalone web application concept please checkout [Application visual layout](application_visual_layout.html) part.
 
@@ -81,6 +75,15 @@ But if you can wait to get to the fun, checkout the more stuff like:
   * [clock](tutorial_clock.md)
   * [gallery](tutorial_gallery.md)
   * [notes](tutorial_notes.md).
+
+
+## History
+
+TAU originated from Tizen Web UI Framework Library (standard library for Tizen 2.2.1),
+which was mainly based as an extension to jQuery Mobile. Key features of the former were
+coding simplification and app creation speed. With that in mind TAU was created as the
+framework *advanced to the next level*. TAU is a standalone UI library, without jQuery
+overhead, but that duo can be used as explained in this [guide later](using_jquery_with_tau.html).
 
 __Have some coding fun!__
 


### PR DESCRIPTION
[Problem] Start page has a lot of text, important information is not on the beginning.
No reference to WATT
[Solution] Simplify welcome page. Move less important sections to the end. Add short note about WATT