### PR TITLE
Tabbar: remove gray area in tabs with title and icon

### DIFF
--- a/src/css/profile/mobile/changeable/common/tabbar.less
+++ b/src/css/profile/mobile/changeable/common/tabbar.less
@@ -18,6 +18,7 @@
 				height: (42 + 4) * @unit_base;
 				padding-bottom: 3 * @unit_base;
 				margin-top: 3 * @unit_base;
+				line-height: (42 + 4) * @unit_base;
 			}
 			&::after {
 				content: "";


### PR DESCRIPTION
[Issue] http://suprem.sec.samsung.net/jira/browse/SAD-527
[Problem] Tabbar: Title & icon tab displays wrongly
[Solution]
Displaying gray area is inconsistent for each web browser.
Setting of line-height style solves this issue.

[Test]
- UIComponents/components/navigationelements/tabs/tabs_icon_with_title_4.html

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>