### PR TITLE
DropDownMenu: fix position of popup with menu options

### DIFF
--- a/src/js/profile/mobile/widget/mobile/DropdownMenu.js
+++ b/src/js/profile/mobile/widget/mobile/DropdownMenu.js
@@ -889,6 +889,7 @@
 				} else if (optionWrapperClassList.contains(classes.closing) || optionWrapperClassList.contains(classes.opening)) {
 					return;
 				} else {
+					ui.elSelectWrapper.focus();
 					optionWrapperClassList.add(classes.opening);
 					self._callbacks.showAnimationEnd = showAnimationEndHandler.bind(null, self);
 					eventUtils.prefixedFastOn(optionContainer, "animationEnd", self._callbacks.showAnimationEnd, false);


### PR DESCRIPTION
[Problem] The popup with options in DropDownMenu widget has wrong position
[Solution] If label reffering to DropDownMenu is positioned far from widget
then popup with menu options is showing in wrong place.
This patch sets focus on DropDownMenu before show the popup.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>