### PR TITLE
Colored listview: fix a gray area below the screen

### DIFF
--- a/examples/mobile/Tizen_Web_UI_FW_Globalize/js/app.js
+++ b/examples/mobile/Tizen_Web_UI_FW_Globalize/js/app.js
@@ -86,6 +86,9 @@
 		/* Updates the text of current language element */
 		currentLanguage.innerHTML = selectedLocaleInstance.getLocale();
 		output(syntaxHighlight(calendarData));
+
+		// Update colored list
+		tau.widget.Listview(document.querySelector(".ui-page-active .ui-listview")).refresh();
 	}
 
 	/**

--- a/src/js/profile/mobile/widget/mobile/Listview.js
+++ b/src/js/profile/mobile/widget/mobile/Listview.js
@@ -426,7 +426,7 @@
 				canvasHeight = Math.max(rect.height, canvasHeight) + self._topOffset;
 
 				// limit canvas for better performance
-				canvasHeight = Math.min(canvasHeight, 3 * window.innerHeight);
+				canvasHeight = Math.min(canvasHeight, 4 * window.innerHeight);
 				self._canvasHeight = canvasHeight;
 				self._canvasWidth = canvasWidth;
 


### PR DESCRIPTION
[Problem] In app TAU Globalization appears a gray area below the screen
[Solution] The colored listview require from developers to call method
 "refresh()" on change content of the list which cause resize of list items

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>