### PR TITLE
TextEnveloper: fix wrong position of clear button

### DIFF
--- a/src/css/profile/mobile/changeable/common/textenveloper.less
+++ b/src/css/profile/mobile/changeable/common/textenveloper.less
@@ -205,6 +205,10 @@ tau-textenveloper {
 			display: none;
 		}
 	}
+
+	input.ui-text-input ~ .ui-text-input-clear {
+		top: auto;
+	}
 }
 
 .ui-listview {


### PR DESCRIPTION
[Problem] Text is cut in text Enveloper
[Solution] Position of clear button has fixed for standard text input
but in TextEvnveloper this position has to be fited to this widget.
Top position has been changed to "auto".

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>