### PR TITLE
Textinput: Move cursor at the end of the existing text

### DIFF
--- a/src/js/profile/wearable/widget/wearable/TextInput.js
+++ b/src/js/profile/wearable/widget/wearable/TextInput.js
@@ -110,6 +110,8 @@
 
 				inputElement.focus();
 
+				inputElement.selectionStart = inputElement.value.length;
+
 				utilEvent.on(inputElement, "blur", self._hideInputPaneBound, true);
 				utilEvent.on(window, "resize", self._windowResizeBound, true);
 				utilEvent.on(window, "tizenhwkey", self._onHWKeyBound, true);


### PR DESCRIPTION
[Problem] If input already contained text cursor was always
          placed at the begining of text content
[Solution] Set coursor to last position
           after focusing on text input

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>