### PR TITLE
PopupToast: Fix text overload

### DIFF
--- a/examples/wearable/UIComponents/contents/popup/popup_toast.html
+++ b/examples/wearable/UIComponents/contents/popup/popup_toast.html
@@ -43,8 +43,7 @@
 
 	<div id="small-popup-toast" class="ui-popup ui-toast-popup ui-popup-toast-small">
 		<div class="ui-popup-content">
-			Your mobile<br>
-			network is not available
+			Network is not available
 		</div>
 	</div>
 

--- a/src/css/profile/wearable/changeable/theme-circle/popup.less
+++ b/src/css/profile/wearable/changeable/theme-circle/popup.less
@@ -379,7 +379,7 @@
 			.ui-popup-wrapper {
 				.ui-popup-content {
 					padding: 0 19 * @unit_base;
-					max-height: 96 * @unit_base;
+					max-height: 128 * @unit_base;
 					color: @color_toast_popup_small_text;
 					font-size: 24 * @unit_base;
 					line-height: 32 * @unit_base;


### PR DESCRIPTION
[Problem] Whole text is not visible in Toast Popup widget.
[Solution] Raise max-height of ui-popup-content class to show one more line of text.

Signed-off-by: Wojciech Szczepanski <w.szczepansk@samsung.com>