### PR TITLE
TextInput: fix issue with overlapping "send" button and "clear" button

### DIFF
--- a/src/css/profile/mobile/changeable/common/textinput.less
+++ b/src/css/profile/mobile/changeable/common/textinput.less
@@ -251,6 +251,20 @@ textarea.ui-text-input {
 			}
 		}
 	}
+
+	input.ui-text-input {
+		& ~ .ui-text-input-clear {
+			right: 10 * @unit_base;
+			left: 10 * @unit_base;
+		}
+		&:focus {
+			&.ui-text-input-clear-active {
+				padding-right: 40 * @unit_base;
+				margin-right: -30 * @unit_base;
+			}
+		}
+	} 
+
 }
 
 .ui-listview li.ui-textinput-box-with-right-button {


### PR DESCRIPTION
[Problem] Clear button in TextInput (X icon) overlaps the "send" button
[Solution] The fix for issue required the change of css styles
for TextInput widget with button.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>