### PR TITLE
Listview: fix selection of item from outside

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/arclistview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/arclistview.less
@@ -21,6 +21,10 @@
 				top: 54 * @unit_base;
 				transform: translateY(-50%);
 			}
+
+			&-hidden {
+				display: none;
+			}
 		}
 	}
 

--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -215,7 +215,8 @@
 					DIVIDER: "ui-listview-divider",
 					FORCE_RELATIVE: "ui-force-relative-li-children",
 					LISTVIEW: "ui-listview",
-					SELECTED: "ui-arc-listview-selected"
+					SELECTED: "ui-arc-listview-selected",
+					HIDDEN_CAROUSEL_ITEM: WIDGET_CLASS + "-carousel-item-hidden"
 				},
 				events = {
 					CHANGE: "change"
@@ -515,8 +516,6 @@
 					carouselItem,
 					carouselElement,
 					itemElement,
-					carouselItem,
-					carouselElement,
 					carouselSeparator,
 					upperSeparator,
 					lowerSeparator,
@@ -647,6 +646,13 @@
 
 					carouselItemElement.style.transform = "translateY(" + top + "px)";
 					carouselItemUpperSeparatorElement.style.transform = "translateY(" + separatorTop + "px)";
+
+					// hide unsed carousel items
+					if (carouselItemElement.firstElementChild === null) {
+						carouselItemElement.classList.add(classes.HIDDEN_CAROUSEL_ITEM);
+					} else {
+						carouselItemElement.classList.remove(classes.HIDDEN_CAROUSEL_ITEM);
+					}
 				}
 			};
 
@@ -1142,12 +1148,12 @@
 						return item.element;
 					}).indexOf(li);
 
-				if (toIndex && toIndex !== state.currentIndex) {
+				if (toIndex > -1 && toIndex !== state.currentIndex) {
 					self.trigger(events.CHANGE, {
 						"unselected": state.currentIndex
 					});
 
-					if (toIndex >= 0 && toIndex < state.items.length) {
+					if (toIndex < state.items.length) {
 						state.toIndex = toIndex;
 					}
 

--- a/tests/js/profile/wearable/widget/wearable/ArcListview/ArcListview.js
+++ b/tests/js/profile/wearable/widget/wearable/ArcListview/ArcListview.js
@@ -14,6 +14,9 @@
 			});
 		}
 
+		function nop() {
+			// nop method;
+		}
 		function clearHTML() {
 			helpers.removeTAUStyle(document);
 		}
@@ -549,15 +552,30 @@
 				scroll: {
 					current: 5
 				},
-				selectors: [],
+				selectors: []
 			};
 			arclistWidget._carousel = {
 				items: [
-					{carouselElement: {style: {}}, carouselSeparator: {style: {}}},
-					{carouselElement: {style: {}}, carouselSeparator: {style: {}}},
-					{carouselElement: {style: {}}, carouselSeparator: {style: {}}},
-					{carouselElement: {style: {}}, carouselSeparator: {style: {}}},
-					{carouselElement: {style: {}}, carouselSeparator: {style: {}}}
+					{carouselElement: {style: {}, "classList": {
+						"add": nop,
+						"remove": nop
+					}}, carouselSeparator: {style: {}}},
+					{carouselElement: {style: {}, "classList": {
+						"add": nop,
+						"remove": nop
+					}}, carouselSeparator: {style: {}}},
+					{carouselElement: {style: {}, "classList": {
+						"add": nop,
+						"remove": nop
+					}}, carouselSeparator: {style: {}}},
+					{carouselElement: {style: {}, "classList": {
+						"add": nop,
+						"remove": nop
+					}}, carouselSeparator: {style: {}}},
+					{carouselElement: {style: {}, "classList": {
+						"add": nop,
+						"remove": nop
+					}}, carouselSeparator: {style: {}}}
 				]
 			};
 			arclistWidget._carouselUpdate(2);
@@ -567,6 +585,10 @@
 						"carouselElement": {
 							"style": {
 								"transform": "translateY(22px)"
+							},
+							"classList": {
+								"add": nop,
+								"remove": nop
 							}
 						},
 						"carouselSeparator": {
@@ -578,7 +600,10 @@
 					{
 						"carouselElement": {
 							"style": {
-
+							},
+							"classList": {
+								"add": nop,
+								"remove": nop
 							}
 						},
 						"carouselSeparator": {
@@ -590,7 +615,10 @@
 					{
 						"carouselElement": {
 							"style": {
-
+							},
+							"classList": {
+								"add": nop,
+								"remove": nop
 							}
 						},
 						"carouselSeparator": {
@@ -602,7 +630,10 @@
 					{
 						"carouselElement": {
 							"style": {
-
+							},
+							"classList": {
+								"add": nop,
+								"remove": nop
 							}
 						},
 						"carouselSeparator": {
@@ -614,7 +645,10 @@
 					{
 						"carouselElement": {
 							"style": {
-
+							},
+							"classList": {
+								"add": nop,
+								"remove": nop
 							}
 						},
 						"carouselSeparator": {


### PR DESCRIPTION
[Problem] Listview: Text blink when tap on outside
[Solution] Not used carousels items captured the tap events.
This caused the issue in widget. Not used carousel items have been hidden.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>