### PR TITLE
Listview (waearble): js errors when building ArcListview

### DIFF
--- a/src/js/core/engine.js
+++ b/src/js/core/engine.js
@@ -203,10 +203,11 @@
 			 * @member ns.engine
 			 * @static
 			 */
-			function defineWidget(name, selector, methods, widgetClass, namespace, redefine, widgetNameToLowercase, BaseElement) {
+			function defineWidget(name, selector, methods, widgetClass, namespace, redefine, widgetNameToLowercase, BaseElement, buildOptions) {
 				var definition;
 				// Widget name is absolutely required
 
+				buildOptions = buildOptions || {};
 				if (name) {
 					if (!widgetDefinitions[name] || redefine) {
 						//>>excludeStart("tauDebug", pragmas.tauDebug);
@@ -222,7 +223,8 @@
 							widgetClass: widgetClass || null,
 							namespace: namespace || "",
 							widgetNameToLowercase: widgetNameToLowercase === undefined ? true : !!widgetNameToLowercase,
-							BaseElement: BaseElement
+							BaseElement: BaseElement,
+							buildOptions: buildOptions
 						};
 
 						widgetDefinitions[name] = definition;
@@ -1186,6 +1188,10 @@
 					// If didn't found binding build new widget
 					if (!binding && widgetDefinitions[name]) {
 						definition = widgetDefinitions[name];
+						if (definition.buildOptions.requireMatchSelector &&
+							!ns.util.selectors.matchesSelector(element, definition.selector)) {
+							return null;
+						}
 						element = processHollowWidget(element, definition, options);
 						binding = getBinding(element, name);
 					} else if (binding) {

--- a/src/js/profile/wearable/widget/wearable/Listview.js
+++ b/src/js/profile/wearable/widget/wearable/Listview.js
@@ -106,11 +106,16 @@
 
 			engine.defineWidget(
 				"Listview",
-				".ui-listview",
+				".ui-listview:not(.ui-arc-listview-carousel-item)",
 				[],
 				Listview,
 				"wearable",
-				true
+				true,
+				false,
+				null,
+				{
+					requireMatchSelector: true
+				}
 			);
 			//>>excludeStart("tauBuildExclude", pragmas.tauBuildExclude);
 			return Listview;


### PR DESCRIPTION
[Solution]
To solve this issue has needed changes in engine.
Added new option to define widget.
Option: buildOptions.requireMatchSelector means that widget can build
 only on defined selector.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>
