### PR TITLE
UIComponents: SwipeList - bugs in example

### DIFF
--- a/examples/wearable/UIComponents/contents/list/list_swipelist.js
+++ b/examples/wearable/UIComponents/contents/list/list_swipelist.js
@@ -1,8 +1,8 @@
 /*global tau */
 (function () {
 
-	var page = document.getElementById("swipelist"),
-		listElement = page.getElementsByClassName("ui-swipelist-list")[0],
+	var page = document.getElementById("page-swipelist"),
+		listElement = page.getElementsByClassName("ui-listview")[0],
 		swipeList;
 
 	/**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/52
[Problem] UIComponents throws console errors
[Solution] In the app were bugs.
- mismatched page id in html and js code
- wrong id of listview

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>