### PR TITLE
Fix listview divider style on non built list

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/listview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/listview.less
@@ -339,7 +339,7 @@
 	}
 
 	&:not(.ui-arc-listview):not(.ui-arc-listview-carousel-item):not(.ui-snap-listview) {
-		li {
+		li:not(.ui-listview-divider) {
 			padding: 25 * @unit_base 30 * @unit_base 26 * @unit_base;
 			min-height: auto;
 			color: @color_multiline_list_item;


### PR DESCRIPTION
[Problem] List divider in in non built list was treated like group index
[Solution] Use more restricted selector in less file

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>