### PR TITLE
Change flex direction of list elements placed inside 'a' tag

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/listview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/listview.less
@@ -334,6 +334,18 @@
 		}
 	}
 
+	&.ui-snap-listview {
+		li {
+			&:not(.ui-li-has-multiline):not(.li-has-multiline) {
+				a {
+					display: flex;
+					flex-direction: row;
+					justify-content: center;
+				}
+			}
+		}
+	}
+
 	&.ui-arc-listview-carousel-item-separator {
 		height: auto;
 	}


### PR DESCRIPTION
[Problem] If listitem contained some text and icon placed as image
          without classes which define position of the icon
          i.e. "li-has-thumb-right" icon was placed above the text.
          It should be placed in row with text content
[Solution] Add styling for mentioned case

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>