### PR TITLE
Page (core): change calculating of content size

### DIFF
--- a/src/js/core/widget/core/Page.js
+++ b/src/js/core/widget/core/Page.js
@@ -456,7 +456,7 @@
 					}
 
 					if (footer) {
-						bottom = utilsDOM.getElementHeight(footer);
+						bottom = footer.getBoundingClientRect().height;
 						contentStyle.marginBottom = bottom + "px";
 						contentStyle.paddingBottom = (-bottom) + "px";
 					}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/58 #58 
[Problem] GalleryUI (example from SDK): content is cut on bottom
[Solution] Method for calculating size of content has been changed.
If footer is not displayed then footer has size zero.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>