### PR TITLE
Don't show drop down for labels

### DIFF
--- a/examples/mobile/Tizen_Web_UI_FW_Globalize/index.html
+++ b/examples/mobile/Tizen_Web_UI_FW_Globalize/index.html
@@ -32,18 +32,14 @@
 				<li class="test"></li>
 
 				<li class="ui-group-index">
-					<label for="select-language">Locale Information</label>
-				</li>
-
-				<li class="ui-group-index">
-					<label for="select-language">Current Language:</label>
+					Current language:
 				</li>
 				<li id="currentLanguage">
 					&nbsp;
 				</li>
 
 				<li class="ui-group-index">
-					<label for="select-language">Calendar data:</label>
+					Calendar data:
 				</li>
 				<li id="calendarData">
 					&nbsp;


### PR DESCRIPTION
[Issue] N/A
[Problem] Drop down menu is displayed after clicking on labels
[Solution]
Remove label tag with attribute.
Remove unused locale caption.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>