### PR TITLE
Header/Footer too strong selectors to hide elements

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/layout.less
+++ b/src/css/profile/wearable/changeable/theme-circle/layout.less
@@ -115,6 +115,11 @@ body {
 				}
 			}
 		}
+
+		/* patch for backward compatibility. Current selector for "ui-header" display:flex is too strong */
+		&.ui-hidden, &.hidden {
+			display: none;
+		}
 	}
 
 	.ui-more {
@@ -252,6 +257,11 @@ body {
 			&.ui-btn-icon-only {
 				padding: 14 * @unit_base 0 14 * @unit_base 0;
 			}
+		}
+
+		/* patch for backward compatibility. Current selector for "ui-header" display:flex is too strong */
+		&.ui-hidden, &.hidden {
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/69
[Problem] Header and Footer have too strong selectors to hide by developers
[Solution] This solution is not good but it seems only way to
fix apps where developer want to hide header or footer by class ".hidden".

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>