### PR TITLE
Call Page Widget destroy only for external pages if reversing in history

### DIFF
--- a/src/js/core/widget/core/PageContainer.js
+++ b/src/js/core/widget/core/PageContainer.js
@@ -98,9 +98,6 @@
 			function deferredFunction(fromPageWidget, toPageWidget, self, options) {
 				if (fromPageWidget) {
 					fromPageWidget.onHide();
-					if (options.reverse) {
-						fromPageWidget.destroy();
-					}
 					self._removeExternalPage(fromPageWidget, options);
 				}
 				toPageWidget.onShow();
@@ -372,6 +369,7 @@
 
 				if (options && options.reverse && DOM.hasNSData(fromPageElement, "external") &&
 					fromPageElement.parentNode) {
+					fromPageWidget.destroy();
 					fromPageElement.parentNode.removeChild(fromPageElement);
 					this.trigger(EventType.PAGE_REMOVE);
 				}

--- a/tests/js/core/widget/core/PageContainer/PageContainer.js
+++ b/tests/js/core/widget/core/PageContainer/PageContainer.js
@@ -148,7 +148,7 @@
 			var pageContainer = new PageContainer(),
 				pageElement = document.getElementById("page6");
 
-			expect(22);
+			expect(21);
 
 			helpers.stub(ns.engine, "instanceWidget", function (element, widgetName) {
 				assert.strictEqual(element, pageElement, "page element is correct");
@@ -197,9 +197,6 @@
 				calculatedOptions.deferred.resolve({
 					onHide: function () {
 						assert.ok(1, "called onHide");
-					},
-					destroy: function () {
-						assert.ok(1, "called destroy");
 					}
 				}, {
 					onShow: function () {
@@ -270,12 +267,15 @@
 		});
 
 
-		test("_removeExternalPage", 2, function () {
+		test("_removeExternalPage", 3, function () {
 			var pageContainer = new PageContainer(),
 				pageContainerElement = document.getElementById("qunit-fixture"),
 				pageElement = document.getElementById("page-not-in-container"),
 				newPageWidget = {
-					element: pageElement
+					element: pageElement,
+					destroy: function() {
+						ok(1, "called Page widget destroy");
+					}
 				},
 				options = {
 					reverse: true
@@ -402,6 +402,9 @@
 								count++;
 							}
 						}
+					},
+					destroy: function () {
+						assert.ok(1, "called Page widget destroy");
 					}
 				},
 				toPageWidget = {


### PR DESCRIPTION
[Problem] Page widgets were destroyed each time page history reversed.
[Solution] Destroy only widgets that are built on external pages
           before removing them from DOM tree.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>