### PR TITLE
Fix dissapearing items in ArcListView

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/listview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/listview.less
@@ -112,6 +112,9 @@
 			&:first-child:last-child {
 				padding: 0;
 				margin: 0;
+				justify-content: space-around;
+				display: flex;
+				align-items: center;
 			}
 		}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/88
[Problem] Items that contained 3 line subtext dissapeared
          when they were not focused
[Solution] Restore previously removed styling of 'a' elements
           inside list.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>