### PR TITLE
Add `ui-header` to header in wearable examples

### DIFF
--- a/examples/wearable/Basic/index.html
+++ b/examples/wearable/Basic/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 	<div class="ui-page ui-page-active" id="main">
-		<header>
+		<header class="ui-header">
 			<h2 class="ui-title">TAU Basic</h2>
 		</header>
 		<div class="ui-content ui-content-padding">

--- a/examples/wearable/List/index.html
+++ b/examples/wearable/List/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 	<div class="ui-page ui-page-active" id="main">
-		<header>
+		<header class="ui-header">
 			<h2 class="ui-title">TAU List</h2>
 		</header>
 		<div class="ui-content">


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/46
[Problem] Header doesn't have `ui-header` class so it is broken after
saving document in design-editor.
[Solution] Add this class to header element

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>