### PR TITLE
(mobile) Listview: Sometime colored listview doesn't refresh

### DIFF
--- a/src/js/profile/mobile/widget/mobile/Listview.js
+++ b/src/js/profile/mobile/widget/mobile/Listview.js
@@ -539,6 +539,7 @@
 
 				self._redraw = true;
 				self._lastChange = Date.now();
+				self._previousVisibleElement = null;
 
 				self._prepareColors();
 				self._refreshBackgroundCanvas(self._scrollableContainer, element);


### PR DESCRIPTION
[Issue] N/A
[Problem] File Manager UI is differet from original app.
Background below listview is not filled.
[Solution] Before refreshing the list, the previous visible item
was not reset. This sometimes cauased issue with redraw the list.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>