### PR TITLE
Fix for Radio button position on listview with group index

### DIFF
--- a/src/css/profile/mobile/changeable/common/groupindex.less
+++ b/src/css/profile/mobile/changeable/common/groupindex.less
@@ -17,9 +17,9 @@
 	}
 
 	+ .ui-li-static:not(.li-has-checkbox) {
-		padding: 33 * @unit_base 17 * @unit_base 33 * @unit_base 32 * @unit_base;
-
+		padding-left: 32 * @unit_base;
 	}
+
 	~ .ui-li-static {
 		> input[type=checkbox] {
 			position: absolute;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/119
[Problem] Radio button on listview with group index has wrong position
[Solution] Setting padding only at left is solving the issue.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>