### PR TITLE
DropDownMenu: fix for duplicates wrapper layer on refresh

### DIFF
--- a/src/js/profile/mobile/widget/mobile/DropdownMenu.js
+++ b/src/js/profile/mobile/widget/mobile/DropdownMenu.js
@@ -509,6 +509,10 @@
 				this.options.inline = value;
 			};
 
+			prototype._getContainer = function () {
+				return this._ui.elSelectWrapper;
+			}
+
 			/**
 			 * Build structure of DropdownMenu widget
 			 * @method _build
@@ -611,24 +615,31 @@
 			 */
 			prototype._buildFilter = function (element, elementId) {
 				var ui = this._ui,
-					screenFilterElement = document.createElement("div"),
-					optionWrapperElement = document.createElement("div"),
-					optionContainerElement = document.createElement("ul"),
+					screenFilterElement = ui.screenFilter,
+					optionWrapperElement = ui.elOptionWrapper,
+					optionContainerElement = ui.elOptionContainer,
 					fragment = document.createDocumentFragment();
 
-				screenFilterElement.classList.add(classes.filter, classes.filterHidden);
-				screenFilterElement.id = elementId + "-overlay";
+				if (!screenFilterElement) {
+					screenFilterElement = document.createElement("div");
+					screenFilterElement.classList.add(classes.filter, classes.filterHidden);
+					screenFilterElement.id = elementId + "-overlay";
+					fragment.appendChild(screenFilterElement);
+				}
 
-				optionWrapperElement.className = classes.optionsWrapper;
-				optionWrapperElement.id = elementId + "-options-wrapper";
+				if (!optionWrapperElement) {
+					optionWrapperElement = document.createElement("div");
+					optionWrapperElement.className = classes.optionsWrapper;
+					optionWrapperElement.id = elementId + "-options-wrapper";
+					fragment.appendChild(optionWrapperElement);
+				}
 
-				optionContainerElement.className = classes.optionList;
-				optionContainerElement.id = elementId + "-options";
-
-				optionWrapperElement.appendChild(optionContainerElement);
-
-				fragment.appendChild(screenFilterElement);
-				fragment.appendChild(optionWrapperElement);
+				if (!optionContainerElement) {
+					optionContainerElement = document.createElement("ul"),
+					optionContainerElement.className = classes.optionList;
+					optionContainerElement.id = elementId + "-options";
+					optionWrapperElement.appendChild(optionContainerElement);
+				}
 				ui.page.appendChild(fragment);
 
 				ui.elOptionContainer = optionContainerElement;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/122
[Problem] Widget has frozen after refresh method
[Solution] Issue connected two bugs
 - lack of protected method _getContainer in the widget
 - issue in _buildFilter method, this method didn't take account
   already existing elements

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>