### PR TITLE
Change padding for list item after list group index

### DIFF
--- a/src/css/profile/mobile/changeable/common/groupindex.less
+++ b/src/css/profile/mobile/changeable/common/groupindex.less
@@ -16,8 +16,9 @@
 		bottom: 7 * @unit_base;
 	}
 
-	+ .ui-li-static:not(.li-has-checkbox) {
-		padding-left: 32 * @unit_base;
+	+ .ui-li-static {
+		padding-top: 33 * @unit_base;
+		padding-bottom: 33 * @unit_base;
 	}
 
 	~ .ui-li-static {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/119
[Problem] Selector for item after group index is too strong for padding
[Solution] This padding is needed to compensate width of underline for group index.
Insted of set whole padding is enough to set top and bottom padding.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>