### PR TITLE
Mobile: Fix estimation of left element's height for virtual list

### DIFF
--- a/src/js/core/widget/core/VirtualListview.js
+++ b/src/js/core/widget/core/VirtualListview.js
@@ -923,7 +923,7 @@
 				var self = this,
 					ui = self._ui,
 					options = self.options,
-					scrollview = self.scrollview || self._getScrollView(options, element),
+					scrollview = ui.scrollview || self._getScrollView(options, element),
 					elementRect,
 					scrollviewRect;
 
@@ -1029,6 +1029,7 @@
 			 */
 			prototype._refreshScrollbar = function () {
 				var self = this,
+					currentIndex = self._currentIndex,
 					element = self.element,
 					options = self.options,
 					ui = self._ui,
@@ -1039,7 +1040,7 @@
 				if (options.orientation === VERTICAL) {
 					//Note: element.clientHeight is variable
 					bufferSizePx = parseFloat(element.clientHeight) || 0;
-					listSize = bufferSizePx / options.bufferSize * options.dataLength;
+					listSize = bufferSizePx / options.bufferSize * (options.dataLength - currentIndex);
 
 					if (options.optimizedScrolling) {
 						utilScrolling.setMaxScroll(listSize);


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/109
[Problem] Calculation of estimated height did not
          include current index
[Solution] Include current index in estimation

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>