### PR TITLE
Tabbar: enable Marquee widget for long texts in tabs

### DIFF
--- a/src/css/profile/mobile/changeable/common/tabbar.less
+++ b/src/css/profile/mobile/changeable/common/tabbar.less
@@ -148,7 +148,7 @@
 			padding-bottom: 3 * @unit_base;
 			overflow-x: hidden;
 			display: flex;
-			justify-content: center;
+			justify-content: flex-start;
 			align-items: center;
 			margin-left: 8 * @unit_base;
 			margin-right: 8 * @unit_base;

--- a/src/js/core/widget/core/Marquee.js
+++ b/src/js/core/widget/core/Marquee.js
@@ -250,6 +250,9 @@
 					returnTimeFrame = (textWidth / (textWidth + containerWidth)),
 					returnValue;
 
+				if (self.options.ellipsisEffect === "none") {
+					return null;
+				}
 				if (state > returnTimeFrame) {
 					returnValue = GRADIENTS.RIGHT;
 				} else if (state > 0) {
@@ -268,6 +271,9 @@
 				var returnValue;
 
 				if (isNaN(state)) {
+					return null;
+				}
+				if (this.options.ellipsisEffect === "none") {
 					return null;
 				}
 				if (state === 1) {
@@ -524,6 +530,7 @@
 				self._animation.destroy();
 				self._animation = null;
 				self.element.classList.remove(classes.MARQUEE_GRADIENT);
+				self.element.style.webkitMaskImage = "";
 			};
 
 			/**
@@ -592,7 +599,7 @@
 					stateDOM = self._stateDOM;
 
 				this.option("animation", "stopped");
-				stateDOM.style.webkitMaskImage = GRADIENTS.RIGHT;
+				stateDOM.style.webkitMaskImage = (this.options.ellipsisEffect === "none") ? "" : GRADIENTS.RIGHT;
 				stateDOM.children[0].style.webkitTransform = "translateX(0)";
 				self._render();
 			};

--- a/src/js/core/widget/core/tab/Tabbar.js
+++ b/src/js/core/widget/core/tab/Tabbar.js
@@ -212,6 +212,12 @@
 						autoChange: true,
 						autoPositionSet: true
 					};
+					self._marqueeOptions = {
+						ellipsisEffect: "none",
+						marqueeStyle: "alternate",
+						iteration: 5,
+						delay: 1000
+					};
 				},
 				CLASS_PREFIX = "ui-tabbar",
 				/**
@@ -626,15 +632,48 @@
 			prototype._setActive = function (index) {
 				var self = this,
 					options = self.options,
-					ui = self._ui;
+					ui = self._ui,
+					link,
+					text,
+					marquee,
+					prevStyleValue,
+					linkRect,
+					textRect;
 
 				if (ui.links.length === 0) {
 					return;
 				}
+				// disable previous link
+				link = ui.links[options.active]
+				link.classList.remove(classes.TAB_ACTIVE);
+				text = link.querySelector("." + classes.TABBAR_TEXT);
+				if (text) {
+					marquee = ns.engine.getBinding(text);
+					if (marquee) {
+						marquee.reset();
+						ns.engine.destroyWidget(text);
+					}
+				}
 
-				ui.links[options.active].classList.remove(classes.TAB_ACTIVE);
-				ui.links[index].classList.add(classes.TAB_ACTIVE);
+				// enable new link
+				link = ui.links[index];
+				link.classList.add(classes.TAB_ACTIVE);
 				options.active = index;
+
+				// enable Marquee widget on text content for active tab
+				// if text content is longer then link
+				text = link.querySelector("." + classes.TABBAR_TEXT);
+				if (text) {
+					prevStyleValue = text.style.overflowX;
+					text.style.overflowX = "visible";
+					textRect = text.getBoundingClientRect();
+					linkRect = link.getBoundingClientRect();
+					text.style.overflowX = prevStyleValue;
+					if (textRect.width > linkRect.width) {
+						ns.widget.Marquee(text, self._marqueeOptions);
+					}
+				}
+
 				self._setTabbarPosition();
 				TabPrototype._setActive.call(self, index);
 			};

--- a/src/js/mobile.js
+++ b/src/js/mobile.js
@@ -96,6 +96,7 @@
 			"./profile/mobile/widget/mobile/Scrollview",
 			"./profile/mobile/widget/mobile/Expandable",
 			"./profile/mobile/widget/mobile/Listview",
+			"./core/widget/core/Marquee",
 			"./core/widget/core/tab/Tabbar",
 			"./profile/mobile/widget/mobile/TextInput",
 			"./profile/mobile/widget/mobile/DropdownMenu",


### PR DESCRIPTION
[Issue] N/A
[Problem] Long text in tabs are cutted and unreadable
[Solution]
- implementation Marquee widget in mobile profile
- added Marquee widget for long text in tabs
- Marquee is enabled on active tab

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>