### PR TITLE
Add missing stylesheet declarations for UIComponents pages

### DIFF
--- a/examples/mobile/UIComponents/components/controls/floatingactions/index.html
+++ b/examples/mobile/UIComponents/components/controls/floatingactions/index.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.min.css">
-	<link rel="stylesheet" href="../../css/style.css">
-	<script type="text/javascript" src="../../lib/tau/mobile/js/tau.min.js" data-build-remove="false"></script>
+	<meta name="viewport" content="width=device-width,user-scalable=no"/>
+	<link rel="stylesheet" href="../../../lib/tau/mobile/theme/default/tau.min.css">
+	<link rel="stylesheet" href="../../../css/style.css">
+	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
 </head>
 <body>
 <div class="ui-page" id="floating-actions-demo-page">

--- a/examples/mobile/UIComponents/components/controls/floatingactions/on-listview.html
+++ b/examples/mobile/UIComponents/components/controls/floatingactions/on-listview.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<meta name="viewport" content="width=device-width,user-scalable=no"/>
+	<link rel="stylesheet" href="../../../lib/tau/mobile/theme/default/tau.min.css">
+	<link rel="stylesheet" href="../../../css/style.css">
 	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
 </head>
 <body>

--- a/examples/mobile/UIComponents/components/controls/floatingactions/on-page.html
+++ b/examples/mobile/UIComponents/components/controls/floatingactions/on-page.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<meta name="viewport" content="width=device-width,user-scalable=no"/>
+	<link rel="stylesheet" href="../../../lib/tau/mobile/theme/default/tau.min.css">
+	<link rel="stylesheet" href="../../../css/style.css">
 	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
 </head>
 <body>

--- a/examples/wearable/UIComponents/contents/empty-state/add-items-2-lines.html
+++ b/examples/wearable/UIComponents/contents/empty-state/add-items-2-lines.html
@@ -3,10 +3,11 @@
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
 	<title>Empty State</title>
+	<link rel="stylesheet" href="../../lib/tau/wearable/theme/default/tau.min.css">
 	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../lib/tau/wearable/theme/default/tau.circle.min.css">
 	<link rel="stylesheet" href="../../css/style.css">
-	<link media="all and (-tizen-geometric-shape: circle)" rel="stylesheet"
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../css/style.circle.css">
 </head>
 <body>
@@ -21,6 +22,7 @@
 			</div>
 		</div>
 	</div>
+	<script src="../../js/circle-helper.js"></script>
+	<script src="../../lib/tau/wearable/js/tau.js"></script>
 </body>
-<script src="../../lib/tau/wearable/js/tau.js"></script>
 </html>

--- a/examples/wearable/UIComponents/contents/empty-state/add-items.html
+++ b/examples/wearable/UIComponents/contents/empty-state/add-items.html
@@ -3,10 +3,11 @@
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
 	<title>Empty State</title>
+	<link rel="stylesheet" href="../../lib/tau/wearable/theme/default/tau.min.css">
 	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../lib/tau/wearable/theme/default/tau.circle.min.css">
 	<link rel="stylesheet" href="../../css/style.css">
-	<link media="all and (-tizen-geometric-shape: circle)" rel="stylesheet"
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../css/style.circle.css">
 </head>
 <body>
@@ -21,6 +22,7 @@
 			</div>
 		</div>
 	</div>
+	<script src="../../js/circle-helper.js"></script>
+	<script src="../../lib/tau/wearable/js/tau.js"></script>
 </body>
-<script src="../../lib/tau/wearable/js/tau.js"></script>
 </html>

--- a/examples/wearable/UIComponents/contents/empty-state/index.html
+++ b/examples/wearable/UIComponents/contents/empty-state/index.html
@@ -3,10 +3,11 @@
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
 	<title>Empty State</title>
+	<link rel="stylesheet" href="../../lib/tau/wearable/theme/default/tau.min.css">
 	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../lib/tau/wearable/theme/default/tau.circle.min.css">
 	<link rel="stylesheet" href="../../css/style.css">
-	<link media="all and (-tizen-geometric-shape: circle)" rel="stylesheet"
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../css/style.circle.css">
 </head>
 <body>
@@ -23,6 +24,7 @@
 			</ul>
 		</div>
 	</div>
+	<script src="../../js/circle-helper.js"></script>
+	<script src="../../lib/tau/wearable/js/tau.js"></script>
 </body>
-<script src="../../lib/tau/wearable/js/tau.js"></script>
 </html>

--- a/examples/wearable/UIComponents/contents/empty-state/no-items-2-lines.html
+++ b/examples/wearable/UIComponents/contents/empty-state/no-items-2-lines.html
@@ -3,10 +3,11 @@
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
 	<title>Empty State</title>
+	<link rel="stylesheet" href="../../lib/tau/wearable/theme/default/tau.min.css">
 	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../lib/tau/wearable/theme/default/tau.circle.min.css">
 	<link rel="stylesheet" href="../../css/style.css">
-	<link media="all and (-tizen-geometric-shape: circle)" rel="stylesheet"
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../css/style.circle.css">
 </head>
 <body>
@@ -22,6 +23,7 @@
 			</div>
 		</div>
 	</div>
+	<script src="../../js/circle-helper.js"></script>
+	<script src="../../lib/tau/wearable/js/tau.js"></script>
 </body>
-<script src="../../lib/tau/wearable/js/tau.js"></script>
 </html>

--- a/examples/wearable/UIComponents/contents/empty-state/no-items.html
+++ b/examples/wearable/UIComponents/contents/empty-state/no-items.html
@@ -3,10 +3,11 @@
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
 	<title>Empty State</title>
+	<link rel="stylesheet" href="../../lib/tau/wearable/theme/default/tau.min.css">
 	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../lib/tau/wearable/theme/default/tau.circle.min.css">
 	<link rel="stylesheet" href="../../css/style.css">
-	<link media="all and (-tizen-geometric-shape: circle)" rel="stylesheet"
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		  href="../../css/style.circle.css">
 </head>
 <body>
@@ -21,6 +22,7 @@
 			</div>
 		</div>
 	</div>
+	<script src="../../js/circle-helper.js"></script>
+	<script src="../../lib/tau/wearable/js/tau.js"></script>
 </body>
-<script src="../../lib/tau/wearable/js/tau.js"></script>
 </html>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/145
[Problem] Style declarations for some pages in UIComponents app were missing.
          This caused errors when page was run separately
[Solution] Add missing style declarations

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>