### PR TITLE
(mobile) ToggleSwitch: fix for conflict data-style and style attribute

### DIFF
--- a/examples/mobile/UIComponents/components/controls/toggleswitch.html
+++ b/examples/mobile/UIComponents/components/controls/toggleswitch.html
@@ -38,13 +38,13 @@
 				3. Define toggleswitch based on &lt;input&gt; tag with slider style
 			</li>
 			<li>
-				<input type="checkbox" name="toggle-3" id="toggle-3" class="ui-toggleswitch" data-style="slider"/>
+				<input type="checkbox" name="toggle-3" id="toggle-3" class="ui-toggleswitch" data-appearance="slider"/>
 			</li>
 			<li class="ui-group-index">
 				3-1. Define disabled toggleswitch based on &lt;input&gt; tag with slider style
 			</li>
 			<li>
-				<input type="checkbox" name="toggle-4" id="toggle-4" class="ui-toggleswitch" data-style="slider" disabled/>
+				<input type="checkbox" name="toggle-4" id="toggle-4" class="ui-toggleswitch" data-appearance="slider" disabled/>
 			</li>
 		</ul>
 	</div>

--- a/src/js/profile/mobile/widget/mobile/ToggleSwitch.js
+++ b/src/js/profile/mobile/widget/mobile/ToggleSwitch.js
@@ -92,11 +92,11 @@
 					/**
 					 * Options for widget
 					 * @property {Object} options
-					 * @property {"circle"|"slider"} [options.style="circle"] ToggleSwitch display style
+					 * @property {"circle"|"slider"} [options.appearance="circle"] ToggleSwitch display appearance
 					 * @member ns.widget.mobile.ToggleSwitch
 					 */
 					self.options = {
-						style: "circle"
+						appearance: "circle"
 					},
 					self._ui = {};
 				},
@@ -321,7 +321,7 @@
 					options = this.options;
 
 				if (controlType === "input") {
-					if (options.style === "slider") {
+					if (options.appearance === "slider") {
 						buildToggleSliderBasedOnInputTag(element, toggleContainer);
 					} else {
 						buildToggleBasedOnInputTag(element, divHandler, toggleContainer);


### PR DESCRIPTION
[Issue] N/A
[Problem] ToggleSlider: Widget looks like standard toggleswitch after any style change
[Solution] Name of widget option "data-style" has changed to "data-appearance".

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>