### PR TITLE
Button: fix for positive value of data-inline="false"

### DIFF
--- a/src/js/core/widget/core/Button.js
+++ b/src/js/core/widget/core/Button.js
@@ -378,6 +378,7 @@
 
 				if (inline === undefined) {
 					inline = element.getAttribute("data-inline");
+					inline = (inline === "false") ? false : !!inline;
 				}
 
 				element.classList.toggle(classes.INLINE, inline);


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/154
[Problem] Button: data-inline="false" is treated as positive value
[Solution] In JS a string value "false" is treated as true

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>