### PR TITLE
Add keyboard support for slider widget

### DIFF
--- a/src/css/profile/mobile/changeable/common/slider.less
+++ b/src/css/profile/mobile/changeable/common/slider.less
@@ -9,7 +9,7 @@
 		background-color: @color_slider_active_bg;
 	}
 
-	&:focus {
+	&.ui-focus, &:focus {
 		outline: 4 * @unit_base solid @color_focus_border;
 	}
 

--- a/src/js/core/widget/BaseKeyboardSupport.js
+++ b/src/js/core/widget/BaseKeyboardSupport.js
@@ -135,6 +135,12 @@
 				previousKeyboardWidgets = [],
 				ANIMATION_MIN_TIME = 50;
 
+			document.addEventListener("pagebeforeshow", function () {
+				// TODO: create a map that would store last focused element
+				// on page to restore focus after back action
+				blurOnActiveElement();
+			});
+
 			BaseKeyboardSupport.KEY_CODES = KEY_CODES;
 			BaseKeyboardSupport.EVENTS = EVENTS;
 			BaseKeyboardSupport.CAPTURE_KEYBOARD_ATTR = CAPTURE_KEYBOARD_ATTR;

--- a/src/js/core/widget/BaseKeyboardSupport.js
+++ b/src/js/core/widget/BaseKeyboardSupport.js
@@ -95,6 +95,11 @@
 					left: "left",
 					right: "right"
 				},
+				EVENTS = {
+					taushortkeypress: "taushortkeypress",
+					taulongkeypress: "taulongkeypress"
+				},
+				CAPTURE_KEYBOARD_ATTR = "data-capture-keyboard",
 				selectorSuffix = ":not(." + classes.focusDisabled + ")" +
 								":not(." + ns.widget.BaseWidget.classes.disable + ")",
 				// define standard focus selectors
@@ -131,6 +136,8 @@
 				ANIMATION_MIN_TIME = 50;
 
 			BaseKeyboardSupport.KEY_CODES = KEY_CODES;
+			BaseKeyboardSupport.EVENTS = EVENTS;
+			BaseKeyboardSupport.CAPTURE_KEYBOARD_ATTR = CAPTURE_KEYBOARD_ATTR;
 			BaseKeyboardSupport.classes = classes;
 			/**
 			 * Get focused element.
@@ -1168,10 +1175,19 @@
 						duration: ((delay - 30) >= ANIMATION_MIN_TIME ? delay - 30 : ANIMATION_MIN_TIME),
 						_last: true, // option for function focusOnNeighborhood
 						_filterNeighbors: filterNeighbors // option for function getNeighborhoodLinks
-					};
+					},
+					isActiveElementCapturingKeys = activeElement &&
+													activeElement.hasAttribute(CAPTURE_KEYBOARD_ATTR) &&
+													activeElement.getAttribute(CAPTURE_KEYBOARD_ATTR) === "true";
 
-				// set focus on next element
-				focusOnNeighborhood(self, self.keyboardElement || self.element, options);
+				if (isActiveElementCapturingKeys && event.keyCode !== KEY_CODES.escape) {
+					// if active element is capturing keys than all
+					// keyEvents except of escape key will be delegated to it
+					eventUtils.trigger(activeElement, EVENTS.taulongkeypress, {keyCode: event.keyCode});
+				} else {
+					// set focus on next element
+					focusOnNeighborhood(self, self.keyboardElement || self.element, options);
+				}
 			};
 
 			/**
@@ -1183,18 +1199,27 @@
 			 * @member ns.widget.tv.BaseKeyboardSupport
 			 */
 			prototype._onShortPress = function (event) {
-				var self = this;
+				var self = this,
+					isActiveElementCapturingKeys = activeElement &&
+													activeElement.hasAttribute(CAPTURE_KEYBOARD_ATTR) &&
+													activeElement.getAttribute(CAPTURE_KEYBOARD_ATTR) === "true";
 
 				if (!ns.getConfig("keyboardSupport", false)) {
 					return false;
 				}
 
-				// set focus on next element
-				focusOnNeighborhood(self, self.keyboardElement || self.element, {
-					current: activeElement || getFocusedLink(),
-					event: event,
-					key: event.keyCode
-				});
+				if (isActiveElementCapturingKeys && event.keyCode !== KEY_CODES.escape) {
+					// if active element is capturing keys than all
+					// keyEvents except of escape key will be delegated to it
+					eventUtils.trigger(activeElement, EVENTS.taushortkeypress, {keyCode: event.keyCode});
+				} else {
+					// set focus on next element
+					focusOnNeighborhood(self, self.keyboardElement || self.element, {
+						current: activeElement || getFocusedLink(),
+						event: event,
+						key: event.keyCode
+					});
+				}
 			};
 
 			/**

--- a/src/js/core/widget/core/Slider.js
+++ b/src/js/core/widget/core/Slider.js
@@ -892,6 +892,7 @@
 				var self = this;
 
 				self._ui.barElement.classList.add(classes.SLIDER_FOCUS);
+				self.element.focus();
 			}
 
 			/**
@@ -905,6 +906,7 @@
 
 				self._ui.barElement.classList.remove(classes.SLIDER_FOCUS);
 				self._releaseWidgetFocus();
+				self.element.blur();
 			}
 
 			/**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/158, https://github.com/Samsung/TAU/issues/157
[Problem] Slider should be able to implement it's own keyboard
          handling and switch to this control after beeing
          selected by KeyboardManager. "Change" event was not
          triggered after value change.
[Solution] Add possibility to delegate keyboard
           event handling to widget instance if needed.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>