### PR TITLE
Add missing license header to profile specific stylesheets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,12 +162,31 @@ module.exports = function (grunt) {
 						len,
 						theme,
 						src,
+						profileSpecificFiles = {
+							"tv": {
+								"changeable": ["tau.tv"]
+							},
+							"wearable": {
+								"changeable": ["tau.circle"]
+							}
+						},
 						pushChangableFiles = function (ext) {
 							src = path.join(buildDir[device].theme, version, name) + ext;
 							licenseFiles.push({
 								src: [path.join("license", "Flora") + ".txt", src],
 								dest: src
 							});
+
+							if (profileSpecificFiles.hasOwnProperty(device) &&
+								profileSpecificFiles[device].hasOwnProperty(version)) {
+								profileSpecificFiles[device][version].forEach((name) => {
+									src = path.join(buildDir[device].theme, version, name) + ext;
+									licenseFiles.push({
+										src: [path.join("license", "Flora") + ".txt", src],
+										dest: src
+									});
+								})
+							}
 						},
 						pushNonChangableFiles = function (ext) {
 							src = path.join(buildDir[device].theme, theme.name, name) + ext;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/165
[Problem] tau.circle.css and tau.tv.css did not have
          license header included.
[Solution] Add licence header in during building TAU

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>