### PR TITLE
Fix running bundle for each profile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1483,7 +1483,7 @@ module.exports = function (grunt) {
 			if (stats.hasErrors() || stats.hasWarnings()) {
 				return callback(new Error(stats.toString()));
 			}
-			callback(true);
+			callback(null, true);
 		});
 	}
 
@@ -1491,7 +1491,7 @@ module.exports = function (grunt) {
 		const done = this.async(),
 			profiles = profile ? [profile] : ["tv", "mobile", "wearable"];
 
-		async.series(profiles.map((p) => createBundleProfile.bind(null, p)), done);
+		async.parallel(profiles.map((p) => createBundleProfile.bind(null, p)), done);
 	}
 
 	grunt.initConfig(initConfig);


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/167
[Problem] Bundle was called only for the first given profile.
          Task was interrupted because result of correct run
          was passed like an error.
[Solution] Fix incorrect call and change series to parallel call
           to speed up the process.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>