### PR TITLE
Add tau.circle.css to checkbox wearable example

### DIFF
--- a/examples/wearable/UIComponents/contents/controls/checkbox.html
+++ b/examples/wearable/UIComponents/contents/controls/checkbox.html
@@ -5,6 +5,7 @@
 	<title>Wearable UI</title>
 	<link rel="stylesheet"  href="../../lib/tau/wearable/theme/default/tau.css">
 	<link rel="stylesheet"  href="../../css/style.css">
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"  href="../../css/style.circle.css">
 </head>
 <body>
 	<div class="ui-page">


### PR DESCRIPTION
[Issue]: https://github.com/Samsung/TAU/issues/161
[Problem]: Checkbox doesn't have graphics to its CSS
[Solution]: Add tau.circle.css to checkbox example itself

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>