### PR TITLE
(engine) fix for defering TAU load issue

### DIFF
--- a/src/js/core/engine.js
+++ b/src/js/core/engine.js
@@ -170,7 +170,8 @@
 					WIDGET_BUILT: "widgetbuilt",
 					DESTROY: "taudestroy",
 					BOUND: "bound",
-					WIDGET_INIT: "init"
+					WIDGET_INIT: "init",
+					STOP_ROUTING: "tauroutingstop"
 				},
 				engine;
 
@@ -1021,6 +1022,7 @@
 			 * @member ns.engine
 			 */
 			function stop() {
+				eventUtils.trigger(document, eventType.STOP_ROUTING);
 			}
 
 			/**
@@ -1032,7 +1034,7 @@
 			function destroy() {
 				stop();
 				eventUtils.fastOff(document, "create", createEventHandler);
-				destroyAllWidgets(document.body, true);
+				destroyAllWidgets(document, true);
 				eventUtils.trigger(document, eventType.DESTROY);
 			}
 
@@ -1143,6 +1145,7 @@
 						window.tauPerf.get("framework", "run()");
 					}
 					//>>excludeEnd("tauPerformance");
+					// stop the TAU process if exists before
 					stop();
 
 					eventUtils.fastOn(document, "create", createEventHandler);
@@ -1152,9 +1155,11 @@
 					switch (document.readyState) {
 						case "interactive":
 						case "complete":
+							// build widgets and initiate router
 							build();
 							break;
 						default:
+							// build widgets and initiate router
 							eventUtils.one(document, "DOMContentLoaded", build.bind(engine));
 							break;
 					}

--- a/src/js/core/event/orientationchange.js
+++ b/src/js/core/event/orientationchange.js
@@ -146,7 +146,7 @@
 			*/
 			orientationchange.unbind = function () {
 				window.removeEventListener("orientationchange", checkReportedOrientation, false);
-				body.removeEventListener("throttledresize", detectOrientationByDimensions, false);
+				document.removeEventListener("throttledresize", detectOrientationByDimensions, true);
 				document.removeEventListener(eventType.DESTROY, orientationchange.unbind, false);
 			};
 
@@ -170,7 +170,7 @@
 						}
 						portraitMatchMediaQueryList.addListener(matchMediaHandler);
 					} else {
-						body.addEventListener("throttledresize", detectOrientationByDimensions, false);
+						document.addEventListener("throttledresize", detectOrientationByDimensions, true);
 						detectOrientationByDimensions();
 					}
 				}

--- a/src/js/core/router/Router.js
+++ b/src/js/core/router/Router.js
@@ -658,6 +658,7 @@
 					body.removeEventListener("pagebeforechange", self.pagebeforechangeHandler, false);
 					body.removeEventListener("vclick", self.linkClickHandler, false);
 				}
+				ns.setConfig("pageContainer", null);
 			};
 
 			/**
@@ -1292,6 +1293,9 @@
 					Router.getInstance().init();
 				}, false);
 				document.addEventListener(engine.eventType.DESTROY, function () {
+					Router.getInstance().destroy();
+				}, false);
+				document.addEventListener(engine.eventType.STOP_ROUTING, function () {
 					Router.getInstance().destroy();
 				}, false);
 			}

--- a/src/js/core/widget/BaseWidget.js
+++ b/src/js/core/widget/BaseWidget.js
@@ -1002,7 +1002,9 @@
 			 * @return {boolean} False, if any callback invoked preventDefault on event object
 			 */
 			prototype.trigger = function (eventName, data, bubbles, cancelable) {
-				return eventUtils.trigger(this.element, eventName, data, bubbles, cancelable);
+				if (this.element) {
+					return eventUtils.trigger(this.element, eventName, data, bubbles, cancelable);
+				}
 			};
 
 			/**

--- a/src/js/profile/wearable/widget/wearable/SwipeList.js
+++ b/src/js/profile/wearable/widget/wearable/SwipeList.js
@@ -349,11 +349,11 @@
 			};
 
 			prototype._unbindEvents = function () {
-				ns.event.disableGesture(this.element);
-
 				utilsEvents.off(this.element, "drag dragstart dragend dragcancel swipe", this);
 				utilsEvents.off(document, "scroll touchcancel", this);
 				utilsEvents.off(this.swipeElement, "touchstart touchmove touchend", blockEvent, false);
+
+				ns.event.disableGesture(this.element);
 			};
 
 			prototype.handleEvent = function (event) {

--- a/tests/js/profile/wearable/widget/wearable/SwipeList/swipelist.js
+++ b/tests/js/profile/wearable/widget/wearable/SwipeList/swipelist.js
@@ -33,11 +33,11 @@
 			0, /* button, left */
 			null /* related target */
 		);
-		ev.touches = [{clientX: move.clientX, clientY: move.clientY}];
+		ev.touches = [{clientX: move.clientX, clientY: move.clientY, pageX: move.clientX, pageY: move.clientY}];
 		if (event === "touchend") {
 			ev.touches = [];
 		}
-		ev.changedTouches = [{clientX: move.clientX, clientY: move.clientY}];
+		ev.changedTouches = [{clientX: move.clientX, clientY: move.clientY, pageX: move.clientX, pageY: move.clientY}];
 		el.dispatchEvent(ev);
 	}
 
@@ -64,11 +64,11 @@
 
 		// Simulate swiping
 		triggerTouchEvent(this.li, "touchstart", this.clientXY);
-		triggerTouchEvent(this.li, "touchmove", {clientX: this.left + 10, clientY: this.top});
+		triggerTouchEvent(this.li, "touchmove", {clientX: this.left + 10, clientY: this.top, pageX: this.left + 10, pageY: this.top});
 		ok(this.swipeList.style.display === "block", "Swipe list is displayed");
 
 		setTimeout(function setTimeout() {
-			triggerTouchEvent(this.li, "touchend", {clientX: this.left + 10, clientY: this.top});
+			triggerTouchEvent(this.li, "touchend", {clientX: this.left + 10, clientY: this.top, pageX: this.left + 10, pageY: this.top});
 		}.bind(this), tapholdThreshold);
 
 	});


### PR DESCRIPTION
[Issue] #190
[Problem] If you defer page TAU load in app,
  next instance of TAU app loaded in the same iframe
  is not able to build TAU app
[Solution] The issue was in Router instance.
  The Router contains instance of document body element which
  is uses as page container. After override content of HTML,
  the Router had a wrong instance the page container.

  Additional has changed method engine.stop() before build process
  for stop the Router instance and remove unnecessary
  event listeners.

  The fixes required also method for orientation change based
  throttledresize event. The listener was changed from document body
  to document.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>