### PR TITLE
Edit radio-button template to enable it in DE

### DIFF
--- a/examples/mobile/UIComponents/components/controls/radio.html
+++ b/examples/mobile/UIComponents/components/controls/radio.html
@@ -101,7 +101,7 @@
 			</ul>
 		</div>
 		<link href="styles.css" rel="stylesheet" />
-		<script src="radio.js">
+		<script src="radio.js" async="">
 		</script>
 	</div>
 	<!-- page -->

--- a/examples/mobile/UIComponents/components/controls/radio.js
+++ b/examples/mobile/UIComponents/components/controls/radio.js
@@ -4,7 +4,7 @@
 	 * radios - NodeList object for radios
 	 * radioresult - Indicator for active radio
 	 */
-	var page = document.getElementById("radio-demo"),
+	var page = document.querySelector(".ui-page"),
 		radios = document.querySelectorAll("input[name='radio-choice']"),
 		radioresult = document.querySelector((".radio-result")),
 		idx;


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU-Design-Editor/issues/126
Problem:
	- In DE we need to append #main id to ui-page element because of
back-button working
	- radio.js use this element with its own id to make internal
script logic

Solution: Edit example to use other features than id of main element

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>