### PR TITLE
(code.tizen.org) Fix for missed button image in examples

### DIFF
--- a/examples/wearable/UIComponents/contents/controls/button/icon-button.css
+++ b/examples/wearable/UIComponents/contents/controls/button/icon-button.css
@@ -1,0 +1,5 @@
+/* --- empty class for download project files by wget */
+.wget-download {
+	background-image: url(../../../css/images/gallery_more_opt_save.png);
+	background-image: url(../../../css/images/b_slider_btn_bg.png);
+}

--- a/examples/wearable/UIComponents/contents/controls/button/icon-button.html
+++ b/examples/wearable/UIComponents/contents/controls/button/icon-button.html
@@ -9,6 +9,7 @@
 	<link href="../../../lib/tau/wearable/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../lib/tau/wearable/theme/default/tau.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<link href="../../../css/style.css" rel="stylesheet" />
+	<link href="./icon-button.css" rel="stylesheet" />
 	<link href="../../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
 	<script src="../../../js/circle-helper.js">
 	</script>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/130
[Problem] Not visible button in Button example on code.tizen.org
[Solution] The issue was caused by not standard reference to icon source
in button element. Data-icon attribute is not recognized by browser.
For resolve issue, missing files was defined in app css files.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>