### PR TITLE
UIComponents: GroupIndex has changed if all dependent checkbox are selected

### DIFF
--- a/examples/mobile/UIComponents/components/list/list-select-check.js
+++ b/examples/mobile/UIComponents/components/list/list-select-check.js
@@ -7,13 +7,16 @@
 	function handleChange(e) {
 		var checkbox = e.target,
 			checked = e.target.checked,
-			parent = tau.util.selectors.getClosestByTag(checkbox, "li"), // get parent li element
+			currentLi = tau.util.selectors.getClosestByTag(checkbox, "li"), // get parent li element
 			next = null,
+			previous = null,
+			allSelected = checked,
+			groupIndexCheckbox = null,
 			childCheckbox = null;
 
 		// check if 'change' event originated in a ui-group-index element
-		if (parent && parent.classList.contains("ui-group-index")) {
-			next = parent.nextElementSibling; // set next sibling as next element
+		if (currentLi && currentLi.classList.contains("ui-group-index")) {
+			next = currentLi.nextElementSibling; // set next sibling as next element
 			// iterate over next li elements and stop when a second group index
 			// element is found
 			while (next && next.classList.contains("ui-group-index") === false) {
@@ -26,6 +29,41 @@
 				}
 				// mark next element for iteration
 				next = next.nextElementSibling;
+			}
+		} else if (currentLi) {
+			// this branch has reverse flow when all checkbox below group index are selected
+			// Find previous list element and check
+			previous = currentLi.previousElementSibling;
+			while (previous && !previous.classList.contains("ui-group-index")) {
+				if (allSelected) {
+					// find the input element in li element
+					childCheckbox = previous.querySelector("input[type=checkbox]");
+					allSelected = childCheckbox.checked;
+				}
+				// go to previous element
+				previous = previous.previousElementSibling;
+			}
+			if (previous.classList.contains("ui-group-index")) {
+				// store group index chekcbox to variable
+				groupIndexCheckbox = previous.querySelector("input[type=checkbox]");
+			}
+			// now check elements below selected checkbox
+			if (allSelected && groupIndexCheckbox) {
+				next = currentLi.nextElementSibling;
+				while (next && !next.classList.contains("ui-group-index")) {
+					// find the input element in li element
+					if (allSelected) {
+						childCheckbox = next.querySelector("input[type=checkbox]");
+						allSelected = childCheckbox.checked;
+					}
+					next = next.nextElementSibling;
+				}
+			}
+			// if all checkbox have the same state then update group index
+			if (groupIndexCheckbox) {
+				// change checked status according to originating group index input
+				// element checked flag
+				groupIndexCheckbox.checked = allSelected;
 			}
 		}
 	}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/207
[Problem] Group index doesn't work after select each dependent options
[Solution] The fix is part of UI Components application code.
In previous version was implemented use case when a user select group index checkbox.
This patch make connection also between each checkbox and group index.
If any checkbox will be unchecked then group index also will be unchecked.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>