### PR TITLE
NumberPicker: Added auto width of text in Spin widget

### DIFF
--- a/src/css/profile/wearable/changeable/common/spin.less
+++ b/src/css/profile/wearable/changeable/common/spin.less
@@ -32,4 +32,8 @@
             transition: 300ms opacity linear;
         }
     }
+    &-placeholder {
+        opacity: 0;
+        pointer-events: none;
+    }
 }

--- a/src/js/profile/wearable/widget/wearable/Spin.js
+++ b/src/js/profile/wearable/widget/wearable/Spin.js
@@ -114,7 +114,8 @@
 					NEXT: WIDGET_CLASS + "-item-next",
 					PREV: WIDGET_CLASS + "-item-prev",
 					ENABLED: "enabled",
-					ENABLING: WIDGET_CLASS + "-enabling"
+					ENABLING: WIDGET_CLASS + "-enabling",
+					PLACEHOLDER: WIDGET_CLASS + "-placeholder"
 				},
 
 				prototype = new BaseWidget();
@@ -388,7 +389,13 @@
 			};
 
 			prototype._build = function (element) {
+				var placeholder = document.createElement("div");
+
 				element.classList.add(classes.SPIN);
+				placeholder.classList.add(classes.PLACEHOLDER);
+				element.appendChild(placeholder);
+
+				this._ui.placeholder = placeholder;
 				return element;
 			};
 
@@ -397,6 +404,8 @@
 					animation;
 
 				value = window.parseInt(value, 10);
+				self._ui.placeholder.textContent = value;
+
 				if (isNaN(value)) {
 					ns.warn("Spin: value is not a number");
 				} else if (value !== self.options.value) {
@@ -578,12 +587,14 @@
 			 */
 			prototype._destroy = function () {
 				var self = this,
-					element = self.element;
+					element = self.element,
+					ui = self._ui;
 
 				self._unbindEvents();
-				self._ui.items.forEach(function (item) {
+				ui.items.forEach(function (item) {
 					item.parentNode.removeChild(item);
 				});
+				element.removeChild(ui.placeholder);
 				element.classList.remove(classes.SPIN);
 			};
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/209
[Problem] NumberPicker: Number is cut
[Solution] All elements inside spin widget were positioned absolutely,
this cause that's widget didn't know proper width. For properly get width
of widget we added placeholder.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>