### PR TITLE
UIComponents: removed unnecessary tag "span" from text on list

### DIFF
--- a/examples/wearable/UIComponents/contents/controls/slider/index.html
+++ b/examples/wearable/UIComponents/contents/controls/slider/index.html
@@ -37,10 +37,8 @@
 				</li>
 				<li>
 					<a href="extended_slider_subtitle.html">
-						<span>
-							Extended with
-							subtitle
-						</span>
+						Extended with
+						subtitle
 					</a>
 				</li>
 			</ul>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/211
[Problem] UIComponents: Text is cut on the list /Controls/Slider
[Solution] The solving of issue was removing unnecessary span tag.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>