### PR TITLE
(UIComponents) Fix for popup's look on the list with select mode

### DIFF
--- a/examples/wearable/UIComponents/css/style.circle.css
+++ b/examples/wearable/UIComponents/css/style.circle.css
@@ -563,14 +563,15 @@ li.static::before {
 	transition: none;
 }
 
-#select-all {
-	padding-top: 45px;
-	padding-bottom: 19px;
+#select-all.show {
+	padding: 0;
 }
 
-#deselect-all {
-	padding-top: 19px;
-	padding-bottom: 44px;
+#deselect-all.show {
+	padding: 0;
+}
+li.hide-popup-li {
+	display: none;
 }
 
 /* -------------------------Animation List------------------------ */


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/216
[Problem] UIComponents: Popup not display text after select all
[Solution] Css selectors for listview were stronger then app styles.
Selectors in the app have been made stronger.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>