### PR TITLE
(wearable) UIComponents: VirtualList with button looks wrong

### DIFF
--- a/examples/wearable/UIComponents/contents/list/virtual/1line_btn.html
+++ b/examples/wearable/UIComponents/contents/list/virtual/1line_btn.html
@@ -27,7 +27,7 @@
 		<!-- sample list for virtual list -->
 		<script id="template-1line-btn" type="text">
 			<a href="#" class="ui-btn ui-btn-circle ui-color-blue"></a>
-		<span class="ui-btn-description">${NAME}</span>
+		<a>${NAME}</a>
    </script>
 		<script>
 			window.pageId = "virtual-1line-btn-page";


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/227
[Problem] Buttons on list are hidden under left edge of screen.
[Solution] Sample app was unnecessary styles.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>