### PR TITLE
UIComponents: fix for cuted text in Toast popup

### DIFF
--- a/examples/mobile/UIComponents/components/popup/toast.html
+++ b/examples/mobile/UIComponents/components/popup/toast.html
@@ -31,8 +31,8 @@
 			</ul>
 			<div class="ui-popup ui-popup-toast" data-role="popup" id="popup_toast">
 				<div class="ui-popup-content">
-					Toast popup text Toast popup text Toast p
-					Toast popup text Toast popup text Toast p
+					Toast popup text Toast popup text Toast
+					Toast popup text Toast popup text Toast
 				</div>
 			</div>
 			<div class="ui-popup ui-popup-toast" data-role="popup" id="popup_btn_toast">


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/240
[Problem] UIComponents: Text in Toast popup is cut
[Solution] Text has edited.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>