### PR TITLE
Fix for right padding when horizontal scroll handler is active

### DIFF
--- a/src/css/profile/mobile/changeable/common/scrollview.handler.less
+++ b/src/css/profile/mobile/changeable/common/scrollview.handler.less
@@ -174,5 +174,9 @@
 
 	.ui-scrollview-clip {
 		width: 105%;
+		&[data-direction="x"] {
+			width: 100%;
+			height: 105%;
+		}
 	}
 }


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/242
[Problem] The left/right padding are not same for Horizontal Scroll handler
[Solution] Selectors in css styles have been changed to more specific.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>