### PR TITLE
Fix for cut line of subtext on multiline list

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/listview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/listview.less
@@ -403,10 +403,18 @@
 					flex-direction: column;
 				}
 
-				.ui-li-sub-text, a .ui-li-sub-text{
+				.ui-li-sub-text {
 					color: @color_multiline_list_subtext;
 					font-size: 24 * @unit_base;
 					line-height: 32 * @unit_base;
+				}
+				a {
+					.ui-li-sub-text {
+						width: 100%;
+						text-overflow: ellipsis;
+						display: inline-block;
+						overflow: hidden;
+					}
 				}
 
 				&.ui-li-active {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/247
[Problem] UIComponents: Subtext is cut on multiline list
[Solution] Subtext lines have not ellipsis styles.
New styles were added.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>