### PR TITLE
Display the initial state of radio checkbox

### DIFF
--- a/examples/mobile/UIComponents/components/controls/radio.js
+++ b/examples/mobile/UIComponents/components/controls/radio.js
@@ -11,11 +11,9 @@
 
 	/**
 	 * Updates text for an selected radio
-	 * @param {Event} e
+	 * @param {HTMLElement} target
 	 */
-	function onChangeHandler(e) {
-		var target = e.target;
-
+	function setRadioresultFromTarget(target) {
 		if (target.checked) {
 			radioresult.innerHTML = "The Active Radio is " + target.id;
 		}
@@ -27,7 +25,10 @@
 	 */
 	page.addEventListener("pageshow", function () {
 		for (idx = 0; idx < radios.length; idx++) {
-			radios[idx].addEventListener("change", onChangeHandler);
+			radios[idx].addEventListener("change", function (event) {
+				setRadioresultFromTarget(event.target);
+			});
+			setRadioresultFromTarget(radios[idx]);
 		}
 	});
 }());


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/126
[Problem] "The Active Radio" text wasn't initially set to the selected value
[Solution] Check which option is selected and update the text with it's value

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>