### PR TITLE
Contextual Popup: fix for popup width

### DIFF
--- a/src/css/profile/mobile/changeable/common/contextpopup.less
+++ b/src/css/profile/mobile/changeable/common/contextpopup.less
@@ -39,6 +39,7 @@
 		overflow: auto;
 		margin-left: 32 * @unit_base;
 		margin-right: 32 * @unit_base;
+		width: auto;
 	}
 	:focus {
 		outline: none;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/250
[Problem] Contextual Popup has wrong widht
[Solution] The contextual popup width was inherit from standard popup.
 This was issue. Width "auto" has added to the contextual popup.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>