### PR TITLE
Fix Arclistview highlight height

### DIFF
--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -1249,9 +1249,8 @@
 				if (selectedElement.classList.contains(classes.SELECTED)) {
 					showHighlight(ui.arcListviewSelection, selectedElement);
 				} else {
-					eventUtils.one(selectedElement, "transitionend", function () {
-						showHighlight(ui.arcListviewSelection, selectedElement);
-					});
+					selectedElement.addEventListener("transitionend", this, true);
+					selectedElement.addEventListener("webkitTransitionEnd", this, true);
 					selectedElement.classList.add(classes.SELECTED);
 				}
 			};
@@ -1277,6 +1276,8 @@
 					} else {
 						classList.remove(classes.SELECTION_SHOW);
 						selectedElement = this._state.items[unselectedIndex].element,
+						selectedElement.removeEventListener("transitionend", this, true);
+						selectedElement.removeEventListener("webkitTransitionEnd", this, true);
 						selectedElement.classList.remove(classes.SELECTED);
 						// stop marque;
 						marqueeDiv = selectedElement.querySelector(".ui-arc-listview-text-content");
@@ -1290,6 +1291,22 @@
 					}
 				}
 			};
+
+			/**
+			 * Handler for transitionend event of active element
+			 * @method _onSelectedElementTransitionEnd
+			 * @memberof ns.widget.wearable.ArcListview
+			 * @protected
+			 */
+			prototype._onSelectedElementTransitionEnd = function () {
+				var self = this,
+					selectionElement = self._ui.arcListviewSelection,
+					items = self._state.items,
+					index = self._state.currentIndex,
+					activeElement = items[index].element;
+
+				showHighlight(selectionElement, activeElement);
+			}
 
 			/**
 			 * Handler for click event
@@ -1546,6 +1563,10 @@
 							break;
 						case "currentindexchange" :
 							self._onCurrentIndexChange(event);
+							break;
+						case "transitionend":
+						case "webkitTransitionEnd":
+							self._onSelectedElementTransitionEnd();
 							break;
 					}
 				}

--- a/tests/js/profile/wearable/widget/wearable/ArcListview/ArcListview.js
+++ b/tests/js/profile/wearable/widget/wearable/ArcListview/ArcListview.js
@@ -312,15 +312,18 @@
 		QUnit.test("_selectItem", function (assert) {
 			var listWidget = new ArcListview(),
 				element = document.getElementById("arc-list"),
+				pageElement = document.getElementById("arc-list-page"),
 				liElement = element.querySelector("li"),
 				height = liElement.getBoundingClientRect().height + "px";
 
 			expect(3);
 			listWidget._ui.arcListviewSelection = element;
+			listWidget._ui.page = pageElement;
 			listWidget._state = {
 				items: [{
 					element: liElement
-				}]
+				}],
+				currentIndex: 0
 			};
 
 			listWidget._selectItem(0);
@@ -328,7 +331,7 @@
 			helpers.triggerEvent(liElement, "transitionend");
 
 			assert.ok(element.classList.contains("ui-arc-listview-selection-show"), "list selection element is active");
-			assert.equal(element.style.height, height, "list selection element has proper height");
+			assert.ok(parseInt(element.style.height, 10), parseInt(height, 10), "list selection element has proper height");
 			assert.ok(liElement.classList.contains("ui-arc-listview-selected"), "list selection element is active");
 		});
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/260
[Problem] Height was set only once - before listitem height
          was set to its final value.
[Solution] Add transitionend listener for each modified
           style property

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>