### PR TITLE
IndexScrollbar: Cleaning of white spaces from index

### DIFF
--- a/examples/mobile/UIComponents/components/navigationelements/indexscrollbar.js
+++ b/examples/mobile/UIComponents/components/navigationelements/indexscrollbar.js
@@ -39,7 +39,7 @@
 		scroller = tau.util.selectors.getScrollableParent(document.getElementById("isbList"));
 		len = dividers.length;
 		for (i = 0; i < len; i++) {
-			idx = dividers[i].textContent;
+			idx = dividers[i].textContent.trim();
 			dividerIndexObject[idx] = dividers[i];
 		}
 		isb = new tau.widget.IndexScrollbar(isbElement);

--- a/examples/mobile/UIComponents/components/navigationelements/indexscrollbar_floating_button.js
+++ b/examples/mobile/UIComponents/components/navigationelements/indexscrollbar_floating_button.js
@@ -52,7 +52,7 @@
 		clearButton = header.querySelector(".ui-text-input-clear");
 		len = dividers.length;
 		for (i = 0; i < len; i++) {
-			idx = dividers[i].textContent;
+			idx = dividers[i].textContent.trim();
 			dividerIndexObject[idx] = dividers[i];
 		}
 		isb = new tau.widget.IndexScrollbar(isbElement);

--- a/src/js/profile/mobile/widget/mobile/IndexScrollbar.js
+++ b/src/js/profile/mobile/widget/mobile/IndexScrollbar.js
@@ -182,7 +182,7 @@
 
 				len = elements.length;
 				for (i = 0; i < len; i++) {
-					indices.push(elements[i].textContent);
+					indices.push(elements[i].textContent.trim());
 				}
 				return indices;
 			}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/268
[Problem] IndexScrollbar: Scrollbar item and list position is different
[Solution] Inside index were white spaces which changing widget running.
Text content was trimmed by js code in index and samples.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>