### PR TITLE
Listview: fix for colored background overshadows text content

### DIFF
--- a/src/css/profile/mobile/changeable/common/listview.less
+++ b/src/css/profile/mobile/changeable/common/listview.less
@@ -86,6 +86,7 @@ tau-expandable {
 		top: 0;
 		left: 0;
 		pointer-events: none;
+		z-index: -1;
 
 		// this is feched from listview widget as values for
 		// base color and modifier (content value)


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/271
[Problem] Listview: Colored items texts are brightened after scroll
[Solution] For resolve issue enough to change z-index for colored background.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>