### PR TITLE
Expandable list: fix for history change on toggle switch press

### DIFF
--- a/src/css/profile/mobile/changeable/common/expandable.less
+++ b/src/css/profile/mobile/changeable/common/expandable.less
@@ -19,6 +19,9 @@
 			padding: 10 * @unit_base 113 * @unit_base 12 * @unit_base 32 * @unit_base;
 			height: 40 * @unit_base;
 			line-height: 40 * @unit_base;
+			&:focus {
+				outline: 0;
+			}
 
 			&:active {
 				color: @color_list_divider_text_expandable_press;

--- a/src/js/profile/mobile/widget/mobile/Expandable.js
+++ b/src/js/profile/mobile/widget/mobile/Expandable.js
@@ -294,7 +294,7 @@
 				// Move header out
 				element.insertBefore(expandableHeading, element.firstChild);
 
-				domUtils.wrapInHTML(expandableHeading.childNodes, "<a class='" + classes.uiExpandableHeadingToggle + "' href='#'></a>");
+				domUtils.wrapInHTML(expandableHeading.childNodes, "<a class='" + classes.uiExpandableHeadingToggle + "' tabindex='0'></a>");
 
 				expandableContent = expandableHeading.nextElementSibling;
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/273
[Problem] Expandable List: After expanding list a back required twice press
[Solution] The issue was caused by implementation of keyborad support in tv profile.
Adding "href='#'" attribute without "tabindex='0'" caused history change.
The issue was solve by adding "tabindex" attribute.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>