### PR TITLE
Listview: disable focus on list items when keyboardSupport disabled

### DIFF
--- a/src/js/profile/mobile/widget/mobile/Listview.js
+++ b/src/js/profile/mobile/widget/mobile/Listview.js
@@ -1052,7 +1052,7 @@
 				var target = event.detail.element,
 					liElement = selectorUtils.getClosestByTag(target, "li");
 
-				if (target.tagName === "A") {
+				if (ns.getConfig("keyboardSupport") && (target.tagName === "A")) {
 					liElement.classList.add(classes.ITEMFOCUS);
 				}
 			};
@@ -1061,17 +1061,21 @@
 				var target = event.detail.element,
 					liElement = selectorUtils.getClosestByTag(target, "li");
 
-				if (target.tagName === "A") {
+				if (ns.getConfig("keyboardSupport") && (target.tagName === "A")) {
 					liElement.classList.remove(classes.ITEMFOCUS);
 				}
 			};
 
 			prototype._focus = function (element) {
-				element.classList.add(classes.FOCUS);
+				if (ns.getConfig("keyboardSupport")) {
+					element.classList.add(classes.FOCUS);
+				}
 			}
 
 			prototype._blur = function (element) {
-				element.classList.remove(classes.FOCUS);
+				if (ns.getConfig("keyboardSupport")) {
+					element.classList.remove(classes.FOCUS);
+				}
 			}
 
 			/**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/279
[Problem] MoreMenu: After popup open the first item is highlighted
[Solution] Check keyboardSupport config before focus set

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>