### PR TITLE
PageIndicator: Change conflicting option name

### DIFF
--- a/examples/mobile/UIComponents/components/navigationelements/pageindicator.html
+++ b/examples/mobile/UIComponents/components/navigationelements/pageindicator.html
@@ -17,7 +17,7 @@
 			</h1>
 		</header>
 		<div class="ui-content">
-			<div class="ui-page-indicator" data-number-of-pages="4" style="transform: translate3d(-50%, -50%, 0); bottom: 0; z-index: 101;">
+			<div class="ui-page-indicator" data-number-of-pages="4" data-appearance="dashed">
 			</div>
 			<div class="ui-section-changer" id="hsectionchanger">
 				<!-- section changer has only one child. -->

--- a/examples/mobile/UIComponents/components/navigationelements/pageindicatorDotted.html
+++ b/examples/mobile/UIComponents/components/navigationelements/pageindicatorDotted.html
@@ -17,7 +17,7 @@
 			</h1>
 		</header>
 		<div class="ui-content">
-			<div class="ui-page-indicator" data-number-of-pages="4" data-style="dotted" style="transform: translate3d(-50%, -50%, 0); bottom: 0; z-index: 101;">
+			<div class="ui-page-indicator" data-number-of-pages="4" data-appearance="dotted">
 			</div>
 			<div class="ui-section-changer" id="hsectionchanger">
 				<!-- section changer has only one child. -->

--- a/src/js/core/widget/core/PageIndicator.js
+++ b/src/js/core/widget/core/PageIndicator.js
@@ -74,7 +74,7 @@
 				 * @property {number} [options.numberOfPages=null] Number of pages to be linked to PageIndicator.
 				 * @property {string} [options.layout="linear"] Layout type of page indicator.
 				 * @property {number} [options.intervalAngle=6] angle between each dot in page indicator.
-				 * @property {string} [options.style="dashed"] style of the page indicator "dotted" "dashed"
+				 * @property {string} [options.appearance="dashed"] style of the page indicator "dotted" "dashed"
 				 * @member ns.widget.core.PageIndicator
 				 */
 				this.options = {
@@ -82,7 +82,7 @@
 					numberOfPages: null,
 					layout: "linear",
 					intervalAngle: 6,
-					style: "dashed"
+					appearance: "dashed"
 				};
 			};
 			/**
@@ -101,7 +101,7 @@
 				if (options.layout === layoutType.CIRCULAR) {
 					self._circularPositioning(element);
 				}
-				if (options.style === "dashed") {
+				if (options.appearance === "dashed") {
 					element.classList.add(classes.indicatorDashed);
 				}
 				return element;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/270
[Problem] Option named style was conflicting with style parameter of element
[Solution] Rename style option to appearance

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>