### PR TITLE
Fix cutted processing full circle

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/processing.less
+++ b/src/css/profile/wearable/changeable/theme-circle/processing.less
@@ -36,7 +36,9 @@ Processing
 		pointer-events: none;
 		position: fixed;
 		width: 100vw;
-		height: 100vw;
+		height: 100vh;
+		max-width: 100vw;
+		max-height: 100vh;
 		top: 0;
 		left: 0;
 		margin: 0;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/285
[Problem] Maximum width was set less than screen width.
[Solution] Override maximum width and height style.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>