### PR TITLE
Change z-index of full processing widget

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/processing.less
+++ b/src/css/profile/wearable/changeable/theme-circle/processing.less
@@ -42,6 +42,7 @@ Processing
 		top: 0;
 		left: 0;
 		margin: 0;
+		z-index: 1000;
 	}
 }
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/315
[Problem] ArcListview highlight effec
          was overlapping processing bar
[Solution] Change z-index of processing widget

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>