### PR TITLE
Change z-index of SnapList highlight

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/listview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/listview.less
@@ -326,6 +326,7 @@
 					background-color: @color_listview_focus;
 					border-radius: 20vw;
 					pointer-events: none;
+					z-index: -1;
 				}
 			}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/280
[Problem] SnapListview had dimmed content - it was caused by
          highlight drawn above of listview element
[Solution] Change z-index of highlight effect.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>