### PR TITLE
Button: fix for icon position on button without text

### DIFF
--- a/src/js/core/widget/core/Button.js
+++ b/src/js/core/widget/core/Button.js
@@ -422,7 +422,7 @@
 			prototype._setIconpos = function (element, iconpos) {
 				var options = this.options,
 					style = options.style,
-					innerTextLength = element.textContent.length || (element.value ? element.value.length : 0);
+					innerTextLength = element.textContent.trim().length || (element.value ? element.value.length : 0);
 
 				iconpos = iconpos || options.iconpos;
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/274
[Problem] Buttons: Icon on button is not centered
[Solution] By default icon position is set to left when text content
 is not empty. But buttons didn't take account white spaces.
 This change makes trim() on text content to remove white spaces.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>