### PR TITLE
TextInput: fix for postion of clear button icon in search input

### DIFF
--- a/examples/mobile/UIComponents/components/controls/textinput.html
+++ b/examples/mobile/UIComponents/components/controls/textinput.html
@@ -27,13 +27,19 @@
 				<li class="ui-li-static">
 					<input data-clear-btn="true" id="texttype" name="texttype" placeholder="Input text here" type="text" />
 				</li>
+				<li class="ui-li-static">
+					<input data-clear-btn="true" id="texttype" name="texttype" placeholder="Input text here" type="text" />
+				</li>
 				<li class="ui-group-index">
 					<label for="textarea">
 						Text Area:
 					</label>
 				</li>
 				<li class="ui-li-static">
-					<textarea id="textarea" name="textarea" placeholder="Input text here" type="text"></textarea>
+					<textarea id="textarea" name="textarea" placeholder="Input text here" type="text" data-clear-btn="true"></textarea>
+				</li>
+				<li class="ui-li-static">
+					<textarea id="textarea" name="textarea" placeholder="Input text here" type="text" data-clear-btn="true"></textarea>
 				</li>
 				<li class="ui-group-index">
 					<label for="texttype2">

--- a/src/css/profile/mobile/changeable/common/textinput.less
+++ b/src/css/profile/mobile/changeable/common/textinput.less
@@ -51,7 +51,6 @@ textarea.ui-text-input {
 				}
 
 				~ .ui-text-input-clear {
-					margin-right: 0;
 					right: 0;
 				}
 
@@ -73,11 +72,6 @@ textarea.ui-text-input {
 				margin: 11 * @unit_base 0 20 * @unit_base 0;
 				position: absolute;
 				width: calc(~"100% - "64 * @unit_base);
-
-			}
-
-			~ .ui-text-input-clear {
-				right: -36 * @unit_base;
 			}
 		}
 	}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/276
[Problem] Search Input: Clear button is moved too much to right
[Solution] Css selectors for clear button position has been changed.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>