### PR TITLE
Tabbar: fix for wrong position of Tab underline

### DIFF
--- a/src/css/profile/mobile/changeable/common/tabbar.less
+++ b/src/css/profile/mobile/changeable/common/tabbar.less
@@ -68,6 +68,12 @@
 				span {
 					align-self: flex-start;
 					top: 4 * @unit_base;
+					line-height: 52 * @unit_base;
+					margin-top: 4 * @unit_base;
+					overflow: hidden;
+					&::before {
+						bottom: 4 * @unit_base;
+					}
 				}
 			}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/267
[Problem] Tabs: Tab underline seems too low
[Solution] Css for text in span element inside tab with title
 has been changed.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>