### PR TITLE
TAU was stopping rotarydetent event propagation

### DIFF
--- a/src/js/core/util/scrolling.js
+++ b/src/js/core/util/scrolling.js
@@ -338,7 +338,6 @@
 					scrollTop: direction ? 0 : -(moveToPosition),
 					fromAPI: false
 				});
-				event.stopImmediatePropagation();
 			}
 
 			function moveToCalculatePosition() {


### PR DESCRIPTION
[Issue] N/A
[Problem] TAU was stopping rotarydetent event
          propagation if scrolling module was enabled.
[Solution] Remove code responsible for stopping event.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>