### PR TITLE
Add missing class in examples

### DIFF
--- a/examples/wearable/UIComponents/contents/list/arclist_marquee_style.html
+++ b/examples/wearable/UIComponents/contents/list/arclist_marquee_style.html
@@ -25,7 +25,7 @@
 		</header>
 		<div class="ui-content">
 			<ul class="ui-listview expand-list" id="snapList">
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient ui-li-anchor">
 						1.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -33,7 +33,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						2.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -41,7 +41,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						3.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -49,7 +49,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						4.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -57,7 +57,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						5.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -65,7 +65,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						6.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -73,7 +73,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						7.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -81,7 +81,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						8.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -89,7 +89,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						9.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -97,7 +97,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						10.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -105,7 +105,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						11.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -113,7 +113,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						12.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -121,7 +121,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						13.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -129,7 +129,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						14.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -137,7 +137,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						15.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -145,7 +145,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						16.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -153,7 +153,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						17.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -161,7 +161,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						18.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -169,7 +169,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						19.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -177,7 +177,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						20.SnapListview with Marquee SnapListview with Marquee
 					</div>

--- a/examples/wearable/UIComponents/contents/list/list_marquee_style.html
+++ b/examples/wearable/UIComponents/contents/list/list_marquee_style.html
@@ -25,7 +25,7 @@
 		</header>
 		<div class="ui-content">
 			<ul class="ui-listview expand-list" id="snapList">
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient ui-li-anchor">
 						1.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -33,7 +33,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						2.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -41,7 +41,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						3.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -49,7 +49,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						4.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -57,7 +57,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						5.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -65,7 +65,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						6.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -73,7 +73,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						7.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -81,7 +81,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						8.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -89,7 +89,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						9.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -97,7 +97,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						10.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -105,7 +105,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						11.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -113,7 +113,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						12.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -121,7 +121,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						13.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -129,7 +129,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						14.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -137,7 +137,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						15.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -145,7 +145,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						16.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -153,7 +153,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						17.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -161,7 +161,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						18.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -169,7 +169,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						19.SnapListview with Marquee SnapListview with Marquee
 					</div>
@@ -177,7 +177,7 @@
 						sub-text
 					</div>
 				</li>
-				<li>
+				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
 						20.SnapListview with Marquee SnapListview with Marquee
 					</div>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/329
[Problem] Examples with multiline list were missing
          required class. It was essential to get correct
          multiline list effect.
[Solution] Add missing classes

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>