### PR TITLE
Extend Selector remove item API

### DIFF
--- a/src/js/profile/wearable/widget/wearable/Selector.js
+++ b/src/js/profile/wearable/widget/wearable/Selector.js
@@ -1821,6 +1821,7 @@
 					itemsOnLayer = self.options.maxItemNumber;
 
 				removeLayers(self.element, self.options);
+
 				element.removeChild(ui.items[index]);
 				ui.items = element.querySelectorAll(self.options.itemSelector);
 				length = ui.items.length;
@@ -1838,6 +1839,22 @@
 
 				self._refresh();
 			};
+
+			/**
+			 * Removes given item from widget
+			 * @method removeGivenItem
+			 * @param {HTMLElement} item
+			 * @public
+			 * @member ns.widget.wearable.Selector
+			 */
+			prototype.removeItemByElement = function (item) {
+				var self = this,
+					index = Array.prototype.indexOf.call(self._ui.items, item);
+
+				if (index !== -1) {
+					self.removeItem(index);
+				}
+			}
 
 			prototype._destroy = function () {
 				var self = this,


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/279
[Problem] Selector item removal API that allows for removing
          items by HTMLElements would be helpful.
[Solution] Extend API to accept both index and HTMLElement

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>