### PR TITLE
TextInput: added distinguished class for container in depend to input type

### DIFF
--- a/examples/mobile/UIComponents/components/controls/textinput.html
+++ b/examples/mobile/UIComponents/components/controls/textinput.html
@@ -27,13 +27,32 @@
 				<li class="ui-li-static">
 					<input data-clear-btn="true" id="texttype" name="texttype" placeholder="Input text here" type="text" />
 				</li>
+				<li class="ui-li-static">
+					<input data-clear-btn="true" id="texttype2" name="texttype" placeholder="Input text here" type="text" />
+				</li>
+				<li class="ui-group-index">
+					<label for="text-input-outside-div">
+						Text input wrapped by container:
+					</label>
+				</li>
+				<li class="ui-li-static">
+					<input data-clear-btn="true" id="text-input-outside-div" name="texttype"
+					placeholder="Input text here" type="text" data-outside-div="true"/>
+				</li>
+				<li class="ui-li-static">
+						<input data-clear-btn="true" id="number-input-outside-div" name="numbertype"
+						placeholder="Input number here" type="number" data-outside-div="true"/>
+				</li>
 				<li class="ui-group-index">
 					<label for="textarea">
 						Text Area:
 					</label>
 				</li>
 				<li class="ui-li-static">
-					<textarea id="textarea" name="textarea" placeholder="Input text here" type="text"></textarea>
+					<textarea id="textarea" name="textarea" placeholder="Input text here" type="text" data-clear-btn="true"></textarea>
+				</li>
+				<li class="ui-li-static">
+					<textarea id="textarea" name="textarea2" placeholder="Input text here" type="text" data-clear-btn="true"></textarea>
 				</li>
 				<li class="ui-group-index">
 					<label for="texttype2">

--- a/src/js/profile/mobile/widget/mobile/TextInput.js
+++ b/src/js/profile/mobile/widget/mobile/TextInput.js
@@ -505,6 +505,7 @@
 				if (newDiv) {
 					container.className = classes.CONTAINER;
 					element.parentElement.replaceChild(container, element);
+					container.classList.add(CLASSES_PREFIX + "-type-" + element.type);
 					container.appendChild(element);
 				}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/234 (TAU Design Editor)
[Problem] The input container does not describe of input field inside.
[Solution] The container is generating during build process. Widget can adds
 specific class name for container in depend to input type.
- Text input examples have extended

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>