### PR TITLE
Add reading of widget properties during refresh

### DIFF
--- a/src/js/core/widget/BaseWidget.js
+++ b/src/js/core/widget/BaseWidget.js
@@ -728,7 +728,10 @@
 			 * @return {ns.widget.BaseWidget}
 			 */
 			prototype.refresh = function () {
-				var self = this;
+				var self = this,
+					element = self.element;
+
+				self._getCreateOptions(element);
 
 				if (typeof self._refresh === TYPE_FUNCTION) {
 					self._refresh.apply(self, arguments);

--- a/src/js/core/widget/core/indexscrollbar/IndexScrollbar.js
+++ b/src/js/core/widget/core/indexscrollbar/IndexScrollbar.js
@@ -463,6 +463,7 @@
 						self._extended(false);
 					}
 
+					self._setIndex(self.element, self.options.index);
 					self._updateLayout();
 					self.indexBar1.options.index = self.options.index;
 					self.indexBar1.refresh();

--- a/tests/js/profile/mobile/widget/mobile/Listview/Listview.js
+++ b/tests/js/profile/mobile/widget/mobile/Listview/Listview.js
@@ -136,6 +136,8 @@
 			popupContainer.classList.add(Listview.classes.POPUP_LISTVIEW);
 
 			listview = new Listview(element);
+			listview.element = element;
+
 			assert.ok(!!listview, "Listview exists");
 
 			helpers.stub(listview, "_refreshColoredBackground", function () {


### PR DESCRIPTION
[Issue] N/A
[Problem] Widgets did not react on attribute
          changes after calling refresh() method.
[Solution] Read widget options from attributes
           before widget refreshing.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>