### PR TITLE
Fix graph plot color property

### DIFF
--- a/src/js/core/widget/core/Graph.js
+++ b/src/js/core/widget/core/Graph.js
@@ -408,7 +408,7 @@
 
 				self.guide = {
 					color: {
-						brewer: self.options.color
+						brewer: self.options.color.split(",")
 					},
 					x: {
 						label: {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/271
[Problem] tauCharts always looks for the color array
[Solution] Add missing conversion to color array

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>