### PR TITLE
FloatingActions: fix for button width

### DIFF
--- a/src/css/profile/mobile/changeable/common/floatingactions.less
+++ b/src/css/profile/mobile/changeable/common/floatingactions.less
@@ -21,6 +21,9 @@
 		height: 120 * @unit_base;
 		margin: 0;
 		background-color: transparent;
+		&.ui-btn-icon {
+			width: 120 * @unit_base;
+		}
 
 		.LESSui-btn-nobg();
 
@@ -113,6 +116,21 @@
 
 		&::before {
 			background-color: @color_floatingactions_icon_press_effect;
+		}
+	}
+}
+
+.ui-listview ~ .ui-floatingactions {
+	.ui-btn {
+		&.ui-btn-icon {
+			&::after {
+				background-color: @color_floatingactions_icon;
+			}
+			&.ui-btn-active {
+				&::after {
+					background-color: @color_floatingactions_icon_press;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/348
[Problem] Floating Button is too wide
[Solution] css selectors have been changed to more specific ones

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>