### PR TITLE
(tests) RadioButton & Checkbox: fix for depracated API synchronous XHTTPRequest

### DIFF
--- a/tests/js/core/widget/core/Checkbox/api/Checkbox.html
+++ b/tests/js/core/widget/core/Checkbox/api/Checkbox.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <div id="qunit"></div>
-<div id="qunit-fixture"></div>
+<div id="qunit-fixture"><input type="checkbox" name="checkbox-1" id="checkbox-1"/></div>
 <script type="text/javascript" src="../../../../../../libs/dist/js/tau.js"></script>
 <script type="text/javascript" src="Checkbox.js"></script>
 </body>

--- a/tests/js/core/widget/core/Checkbox/api/Checkbox.js
+++ b/tests/js/core/widget/core/Checkbox/api/Checkbox.js
@@ -4,10 +4,13 @@
 	function runTests(Checkbox, helpers) {
 
 		function initHTML() {
-			var HTML = helpers.loadHTMLFromFile("/base/tests/js/core/widget/core/Checkbox/test-data/sample.html"),
+			var HTML,
 				parent = document.getElementById("qunit-fixture") || helpers.initFixture();
 
-			parent.innerHTML = HTML;
+			if (parent.innerHTML === "") {
+				HTML = helpers.loadHTMLFromFile("/base/tests/js/core/widget/core/Checkbox/test-data/sample.html");
+				parent.innerHTML = HTML;
+			}
 		}
 
 		module("core/widget/core/Checkbox", {

--- a/tests/js/core/widget/core/Radio/api/Radio.html
+++ b/tests/js/core/widget/core/Radio/api/Radio.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <div id="qunit"></div>
-<div id="qunit-fixture"></div>
+<div id="qunit-fixture"><input type="radio" name="radio-choice" id="radio-choice-1" value="choice-1" checked="checked" /></div>
 <script type="text/javascript" src="../../../../../../libs/dist/js/tau.js"></script>
 <script type="text/javascript" src="Radio.js"></script>
 </body>

--- a/tests/js/core/widget/core/Radio/api/Radio.js
+++ b/tests/js/core/widget/core/Radio/api/Radio.js
@@ -4,10 +4,13 @@
 	function runTests(Radio, helpers) {
 
 		function initHTML() {
-			var HTML = helpers.loadHTMLFromFile("/base/tests/js/core/widget/core/Radio/test-data/sample.html"),
+			var HTML,
 				parent = document.getElementById("qunit-fixture") || helpers.initFixture();
 
-			parent.innerHTML = HTML;
+			if (parent.innerHTML === "") {
+				HTML = helpers.loadHTMLFromFile("/base/tests/js/core/widget/core/Checkbox/test-data/sample.html");
+				parent.innerHTML = HTML;
+			}
 		}
 
 		module("core/widget/core/Radio", {


### PR DESCRIPTION
[Issue] N/A
[Problem] Part of HTML in tests are loaded by synchronous XHTTPRequest,
 this cause issue.
[Solution] Added HTML sample to Checkbox.html. Old code cannot be removed
 because is used by Karma test engine.