### PR TITLE
Set SnapListview scrolling height during refresh

### DIFF
--- a/src/js/profile/wearable/widget/wearable/SnapListview.js
+++ b/src/js/profile/wearable/widget/wearable/SnapListview.js
@@ -473,7 +473,8 @@
 					options = self.options,
 					listItems = [],
 					scroller = ui.scrollableParent.element,
-					visibleOffset;
+					visibleOffset,
+					lastItem;
 
 				if (!scroller) {
 					self._initSnapListview(listview);
@@ -492,6 +493,14 @@
 						self._currentIndex = index;
 					}
 				});
+
+				lastItem = listItems.slice(-1)[0];
+				if (lastItem) {
+					scrolling.setMaxScroll(lastItem.position.end + lastItem.coord.height);
+					scrolling.setSnapSize(lastItem.coord.height);
+				} else {
+					scrolling.setMaxScroll(0);
+				}
 
 				self._listItems = listItems;
 				self._listItemAnimate();


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/366
[Problem] During list refresh height was never changed.
          Newly added elements which did not fit into
          scrollable area could not be selected.
[Solution] Set scrollable area height during widget refresh

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>