### PR TITLE
Change snaplist press effect background color

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/theme.changeable.less
+++ b/src/css/profile/wearable/changeable/theme-circle/theme.changeable.less
@@ -165,7 +165,7 @@
 @color_listview_sub_text_press: T022P;
 @color_listview_sub_text_dim: T022D;
 @color_listview_focus: rgba(48, 48, 48, 0.65); /* B011 */
-@color_listview_focus_press: B0210P;
+@color_listview_focus_press: rgba(81, 81, 81, 0.5); /* B0210P */
 @color_listview_focus_ef: B027;
 @color_listview_focus_ef_press: B027P;
 


### PR DESCRIPTION
[Issue] N/A
[Problem] Listview selection style has changed, the highlight on press
          effect was used from previous listview style.
[Solution] Change highlight color, because of we currently do not have
           color table temporaty set hihglihght color with rgb value.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>