### PR TITLE
(wearable) Selector: fix for scale active item

### DIFF
--- a/src/js/profile/wearable/widget/wearable/Selector.js
+++ b/src/js/profile/wearable/widget/wearable/Selector.js
@@ -334,7 +334,7 @@
 					ITEM_RADIUS: -1,
 					ITEM_START_DEGREE: 30,
 					ITEM_END_DEGREE: 330,
-					ITEM_NORMAL_SCALE: "scale(" + STATIC.SCALE_FACTOR + ")",
+					ITEM_NORMAL_SCALE: "scale(" + (STATIC.SCALE_FACTOR).toString().replace(",", ".") + ")",
 					ITEM_ACTIVE_SCALE: "scale(1)",
 					ITEM_MOVED_SCALE: "scale(0.92)",
 					EMPTY_STATE_TEXT: "Selector is empty"


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/369
[Problem] Option menu icons disappearing on Gear S3
[Solution] Is possible that some devices convert number values
 into string using number format specific for localization region.
 The fix prevents to use comma for decimal places.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>