### PR TITLE
(wearable) Number, Time and Date pickers: remove "set" button on widget destroy

### DIFF
--- a/src/js/profile/wearable/widget/wearable/DatePicker.js
+++ b/src/js/profile/wearable/widget/wearable/DatePicker.js
@@ -536,8 +536,10 @@
 			 * @protected
 			 */
 			prototype._destroy = function () {
-				this._unbindEvents();
-				this.element.innerHTML = "";
+				var self = this;
+
+				self._unbindEvents();
+				self.element.innerHTML = "";
 			};
 
 			/**

--- a/src/js/profile/wearable/widget/wearable/NumberPicker.js
+++ b/src/js/profile/wearable/widget/wearable/NumberPicker.js
@@ -126,6 +126,15 @@
 					label: null,
 					footer: null
 				};
+
+				// property contains information which DOM elements
+				// was built during widget build process.
+				// These data are needed in destroy method
+				self._wasBuilt = {
+					footer: false,
+					buttonSet: false
+				}
+
 			}
 			NumberPicker.classes = classes;
 
@@ -182,6 +191,7 @@
 					if (!footer) {
 						footer = document.createElement("footer");
 						parent.appendChild(footer);
+						this._wasBuilt.footer = true;
 					}
 
 					// add standard footer class for footer with button
@@ -422,6 +432,7 @@
 				buttonSet.classList.add(classes.BUTTON_SET);
 				// add "set" button to the footer
 				footer.appendChild(buttonSet);
+				this._wasBuilt.buttonSet = true;
 
 				// build DOM structure
 				container.appendChild(number);
@@ -472,6 +483,14 @@
 				footer.classList.remove("ui-bottom-button");
 
 				// recovery DOM structure
+				if (self._wasBuilt.buttonSet) {
+					ui.footer.removeChild(ui.buttonSet);
+					self._wasBuilt.buttonSet = false;
+				}
+				if (self._wasBuilt.footer) {
+					ui.footer.parentElement.removeChild(ui.footer);
+					self._wasBuilt.footer = false;
+				}
 				if (container.parentElement) {
 					container.parentElement.replaceChild(self.element, container);
 				}

--- a/src/js/profile/wearable/widget/wearable/TimePicker.js
+++ b/src/js/profile/wearable/widget/wearable/TimePicker.js
@@ -730,8 +730,13 @@
 
 				ui.footer.classList.remove("ui-bottom-button");
 
-				if (ui.footer.children.length) {
+				if (self._wasBuilt.buttonSet) {
 					ui.footer.removeChild(ui.buttonSet);
+					self._wasBuilt.buttonSet = false;
+				}
+				if (self._wasBuilt.footer) {
+					ui.footer.parentElement.removeChild(ui.footer);
+					self._wasBuilt.footer = false;
 				}
 
 				self._unbindEvents();


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/387
[Problem] NumberPicker: auto-created 'Set' button not destroyed
 when calling destroy()
[Solution] Method destroy has been changed for all pickers.
 After this change, if the "set" button was created by widget
 then the button will be removed in destroy method.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>