### PR TITLE
(wearable) Selector: fix for scale active item

### DIFF
--- a/src/js/profile/wearable/widget/wearable/Selector.js
+++ b/src/js/profile/wearable/widget/wearable/Selector.js
@@ -946,13 +946,13 @@
 				if (active) {
 					active.style.transform =
 						active.style.transform.replace(DEFAULT.ITEM_ACTIVE_SCALE,
-							DEFAULT.ITEM_NORMAL_SCALE);
+							DEFAULT.ITEM_NORMAL_SCALE).replace("scale(0,", "scale(0.");
 					active.classList.remove(classes.ITEM_ACTIVE);
 				}
 				if (items.length) {
 					items[index].classList.add(classes.ITEM_ACTIVE);
 					newTransformStyle = transform.replace(DEFAULT.ITEM_NORMAL_SCALE,
-						DEFAULT.ITEM_ACTIVE_SCALE);
+						DEFAULT.ITEM_ACTIVE_SCALE).replace("scale(0,", "scale(0.");
 					items[index].style.transform = newTransformStyle;
 					items[index].style.webkitTransform = newTransformStyle;
 					if (self.options.indicatorAutoControl) {

--- a/src/js/profile/wearable/widget/wearable/Selector.js
+++ b/src/js/profile/wearable/widget/wearable/Selector.js
@@ -945,14 +945,14 @@
 
 				if (active) {
 					active.style.transform =
-						active.style.transform.replace(DEFAULT.ITEM_ACTIVE_SCALE,
-							DEFAULT.ITEM_NORMAL_SCALE).replace("scale(0,", "scale(0.");
+						active.style.transform.replace("scale(0,", "scale(0.").replace(DEFAULT.ITEM_ACTIVE_SCALE,
+							DEFAULT.ITEM_NORMAL_SCALE);
 					active.classList.remove(classes.ITEM_ACTIVE);
 				}
 				if (items.length) {
 					items[index].classList.add(classes.ITEM_ACTIVE);
-					newTransformStyle = transform.replace(DEFAULT.ITEM_NORMAL_SCALE,
-						DEFAULT.ITEM_ACTIVE_SCALE).replace("scale(0,", "scale(0.");
+					newTransformStyle = transform.replace("scale(0,", "scale(0.").replace(DEFAULT.ITEM_NORMAL_SCALE,
+						DEFAULT.ITEM_ACTIVE_SCALE);
 					items[index].style.transform = newTransformStyle;
 					items[index].style.webkitTransform = newTransformStyle;
 					if (self.options.indicatorAutoControl) {


### PR DESCRIPTION
[Issue] #369
[Problem] Upon retrieval of the string after calling .style.transform, the decimal place is replaced by a comma if the watch is set to a display language that uses commas for decimal places.
[Solution] Replace the decimal place comma by a dot.

Improvement (or actually working solution) for #389 