### PR TITLE
Scrolling: Reset current index for snap point list

### DIFF
--- a/src/js/core/util/scrolling.js
+++ b/src/js/core/util/scrolling.js
@@ -578,6 +578,9 @@
 					// detect direction
 					direction = (setDirection === "x") ? 1 : 0;
 
+					// reset current index for new list element
+					currentIndex = 0;
+
 					existingContainerElement = element.querySelector("div." + classes.container);
 					if (existingContainerElement) {
 						childElement = existingContainerElement;


### PR DESCRIPTION
[Issue] N/A
[Problem] Bezel scrolling not working on next list
[Solution] If next list has a less items than previous
 there was issue with snap point list. The current index is reseting
 after this patch.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>