### PR TITLE
(wearable) SnapListview: reverting change of column layout in LI item

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/listview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/listview.less
@@ -193,7 +193,7 @@
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			flex-direction: row;
+			flex-direction: column;
 			a {
 				display: flex;
 				flex-direction: column;
@@ -347,6 +347,11 @@
 					justify-content: center;
 				}
 			}
+		}
+	}
+	&.ui-arc-listview-carousel-item:not(.ui-snap-listview) {
+		li {
+			flex-direction: row;
 		}
 	}
 


### PR DESCRIPTION
[Issue] N/A
[Problem] Snaplitview layout is broken
[Solution] The change of layout direction for LI item in SnapListview
 has been reverted. The column layout has changed only for ArcListview.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>