### PR TITLE
Enabling pointer events for progress circle

### DIFF
--- a/src/css/profile/mobile/changeable/common/progress.less
+++ b/src/css/profile/mobile/changeable/common/progress.less
@@ -97,9 +97,10 @@ tau-progress {
 .ui-progress-circle {
 	position: relative;
 	display: inline-block;
-	pointer-events: none;
 	box-sizing: border-box;
-
+	* {
+		pointer-events: none;
+	}
 	.ui-progress-circle-value.ui-progress-circle-half {
 		box-sizing: border-box;
 		clip: rect(auto, auto, auto, auto);


### PR DESCRIPTION
Issue: #397
Problem: In Design Editor Progress element is not draggable item because
of none pointer-events
Solution: Remove `pointer-events: none` from ui-progress-circle and add
it to its children

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>