### PR TITLE
Prevent to touch screen on rotary event

### DIFF
--- a/src/js/core/util/scrolling.js
+++ b/src/js/core/util/scrolling.js
@@ -393,6 +393,11 @@
 
 				previousIndex = currentIndex;
 
+				if (isTouch) {
+					lastScrollPosition = 0;
+					isTouch = false;
+				}
+
 				// update position by snapSize
 				if (eventDirection === "CW") {
 					currentIndex++;

--- a/src/js/profile/wearable/widget/wearable/SnapListview.js
+++ b/src/js/profile/wearable/widget/wearable/SnapListview.js
@@ -407,6 +407,10 @@
 				setSelection(self);
 			}
 
+			function onRotary(self) {
+				self._isTouched = false;
+			}
+
 			function getScrollableParent(element) {
 				var overflow;
 
@@ -619,6 +623,7 @@
 				self._callbacks.touchstart = onTouchStart.bind(null, self);
 				self._callbacks.touchend = onTouchEnd.bind(null, self);
 				self._callbacks.vclick = vClickHandler.bind(null, self);
+				self._callbacks.rotary = onRotary.bind(null, self);
 
 				if (scrollableElement) {
 					utilEvent.on(scrollableElement, "scroll", this._callbacks.scroll, false);
@@ -626,6 +631,7 @@
 				element.addEventListener("touchstart", self._callbacks.touchstart, false);
 				element.addEventListener("touchend", self._callbacks.touchend, false);
 				element.addEventListener("vclick", self._callbacks.vclick, false);
+				window.addEventListener("rotarydetent", self._callbacks.rotary, false);
 			};
 
 			/**
@@ -645,6 +651,7 @@
 				element.removeEventListener("touchstart", self._callbacks.touchstart, false);
 				element.removeEventListener("touchend", self._callbacks.touchend, false);
 				element.removeEventListener("vclick", self._callbacks.vclick, false);
+				window.removeEventListener("rotarydetent", self._callbacks.rotary, false);
 			};
 
 			/**


### PR DESCRIPTION
[Issue] N/A
[Problem] Scrolling with the wheel causes a problem because
the touch is pressed but not terminated
[Solution] Forces touch termination logic when scrolling using wheel

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>