### PR TITLE
Skip rotary event when the element is not visible

### DIFF
--- a/src/js/core/util/scrolling.js
+++ b/src/js/core/util/scrolling.js
@@ -385,11 +385,25 @@
 			}
 
 			/**
+			 * Check visible state of the element
+			 * @param {Element} elm
+			 */
+			function _isVisible(elm) {
+				var rect = elm.getBoundingClientRect();
+
+				return direction ? rect.width : rect.height;
+			}
+
+			/**
 			 * Handler for rotary event
 			 * @param {Event} event
 			 */
 			function rotary(event) {
 				var eventDirection = event.detail && event.detail.direction;
+
+				if (scrollingElement && !_isVisible(scrollingElement)) {
+					return;
+				}
 
 				previousIndex = currentIndex;
 


### PR DESCRIPTION
[Issue] N/A
[Problem] Even when the screen is not visible, rotary event is applied
[Solution] Skip the rotary event when the element is not visible

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>