### PR TITLE
Add missing btn-text class for button

### DIFF
--- a/examples/wearable/UIComponents/contents/etc/index.html
+++ b/examples/wearable/UIComponents/contents/etc/index.html
@@ -44,7 +44,7 @@
 					Hidden time
 				</li>
 				<li>
-					<button class="ui-btn" id="button_webkitui_hiddendateopener" style="display:block">
+					<button class="ui-btn ui-btn-text" id="button_webkitui_hiddendateopener" style="display:block">
 						Open timepicker
 					</button>
 				</li>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/409
[Problem] Blue highlight was visible if button was active
[Solution] Add missing ui-btn-text only class for button

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>