### PR TITLE
Expandalbe list: apply active state only for it's header

### DIFF
--- a/src/css/profile/mobile/changeable/common/listview.less
+++ b/src/css/profile/mobile/changeable/common/listview.less
@@ -47,8 +47,14 @@ tau-expandable {
 			color: @color_list_main_text_normal;
 		}
 
-		&.ui-li-active {
+		&:not(.ui-expandable).ui-li-active{
 			background-color: @color_list_press;
+		}
+
+		&.ui-li-active.ui-expandable {
+			.ui-expandable-heading {
+				background-color: @color_list_press;
+			}
 		}
 
 		& > a:not(.ui-btn) {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/411
[Problem] The whole expandable section was
          highlighted when clicked
[Solution] Change styling to highlight only header element

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>