### PR TITLE
Change positioning of swipelist item text and icon

### DIFF
--- a/src/css/profile/wearable/changeable/common/swipelist.less
+++ b/src/css/profile/wearable/changeable/common/swipelist.less
@@ -33,7 +33,7 @@
 .ui-swipelist-left .ui-swipelist-icon {
 	// Icon and text need to set position or url and so on.
 	// We thought that swipelist's content style need to be implemented by developer wanted.
-	margin-left: 2%;
+	left: 2%;
 	background-color: @color_list_swipe_icon_btn_call;
 	mask-image: url('./images/Swipelist/b_logs_icon_body_btn_call_nor.png');
 	.mask-repeat(no-repeat);
@@ -42,13 +42,13 @@
 .ui-swipelist-left .ui-swipelist-text {
 	// Icon and text need to set position or url and so on.
 	// We thought that swipelist's content style need to be implemented by developer wanted.
-	margin-left: 40%;
+	left: 40%;
 }
 
 .ui-swipelist-right .ui-swipelist-icon {
 	// Icon and text need to set position or url and so on.
 	// We thought that swipelist's content style need to be implemented by developer wanted.
-	margin-left: 80%;
+	left: 80%;
 	background-color: @color_list_swipe_icon_btn_msg;
 	mask-image: url('./images/Swipelist/b_logs_icon_actionbar_btn_msg_nor.png');
 	.mask-repeat(no-repeat);
@@ -57,5 +57,5 @@
 .ui-swipelist-right .ui-swipelist-text {
 	// Icon and text need to set position or url and so on.
 	// We thought that swipelist's content style need to be implemented by developer wanted.
-	margin-left: 20%;
+	left: 20%;
 }


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/413
[Problem] Text and icon were overlapping each other
          (the problem existed only in wearable emulator)
[Solution] Because both elements were absolute positioned,
           so use `left` property instead `margin-left` to set position.

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>