### PR TITLE
UIComponents: fix for duplicate page ID in bottom button example

### DIFF
--- a/examples/mobile/UIComponents/components/headerfooter/bottombutton.html
+++ b/examples/mobile/UIComponents/components/headerfooter/bottombutton.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-	<div class="ui-page" id="demo-page">
+	<div class="ui-page" id="bottom-button-page">
 		<div class="ui-header" data-position="fixed">
 			<h1>
 				Bottom Button


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/415
[Problem] UIComponents: Can't scroll down to the bottom of screen
 after back
[Solution]
All pages in app have to be uniquely ID. Conflict of page ids make
 issues with routing and page destroy method.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>