### PR TITLE
Page: storing and restoring page scroll position on page change

### DIFF
--- a/src/js/core/widget/core/Page.js
+++ b/src/js/core/widget/core/Page.js
@@ -300,6 +300,7 @@
 
 					self._contentFillAfterResizeCallback = null;
 					self._initialContentStyle = {};
+					self._lastScrollPosition = 0;
 					/**
 					 * Options for widget.
 					 * It is empty object, because widget Page does not have any options.
@@ -882,7 +883,13 @@
 			 * @member ns.widget.core.Page
 			 */
 			prototype.onBeforeShow = function () {
-				this.trigger(EventType.BEFORE_SHOW);
+				var self = this,
+					scroller = self.getScroller();
+
+				if (scroller) {
+					scroller.scrollTop = self._lastScrollPosition || 0;
+				}
+				self.trigger(EventType.BEFORE_SHOW);
 			};
 
 			/**
@@ -907,7 +914,13 @@
 			 * @member ns.widget.core.Page
 			 */
 			prototype.onBeforeHide = function () {
-				this.trigger(EventType.BEFORE_HIDE);
+				var self = this,
+					scroller = self.getScroller();
+
+				if (scroller) {
+					self._lastScrollPosition = scroller.scrollTop;
+				}
+				self.trigger(EventType.BEFORE_HIDE);
 			};
 
 			/**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/417
[Problem] Position of scroll is resetting after back from previous page
[Solution] Position of page scroll is stored before page hide and restored
 before page show.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>