### PR TITLE
(mobile) Drawer: fix for filling colored list in drawer widget

### DIFF
--- a/src/css/profile/mobile/changeable/common/drawer.less
+++ b/src/css/profile/mobile/changeable/common/drawer.less
@@ -1,6 +1,6 @@
 .ui-drawer {
 	position: absolute;
-	background-color: @color_drawer_bg;
+	background-image: url("images/page/core_theme_bg_01.png");
 	z-index: 1201;
 	box-sizing: border-box;
 	overflow-x: hidden;
@@ -18,6 +18,7 @@
 		position: absolute;
 		z-index: 2000;
 		width: 100%;
+		height: 100%;
 		.ui-li.ui-li-last > .ui-btn-inner {
 			// This less code should removed after fixing list widget less code
 			border-bottom-color: @color_list_border_bottom;

--- a/src/css/profile/mobile/changeable/theme-changeable/theme.color.less
+++ b/src/css/profile/mobile/changeable/theme-changeable/theme.color.less
@@ -418,7 +418,7 @@
 //***************************************************************************
 @color_drawer_bg: B011; // #[color] background color
 @color_drawer_list_press: B0211P; // #[color] list item background color
-@color_drawer_overlay_bg: B016; // #[color] overlay color
+@color_drawer_overlay_bg: B060; // B016 (old theme); // #[color] overlay color
 @color_drawer_icon: F043L1i; // #[color] icon color
 @color_drawer_icon_press: F043P; // #[color] background icon press color
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/421
[Problem] Drawer background is blue, It should be white
[Solution]
The colors of drawer widget refers to old version of TAU. CSS has been updated

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>