### PR TITLE
Make SectionChanger resizable

### DIFF
--- a/src/js/core/widget/core/SectionChanger.js
+++ b/src/js/core/widget/core/SectionChanger.js
@@ -160,8 +160,7 @@
 			utilsObject.inherit(SectionChanger, Scroller, {
 				_build: function (element) {
 					var self = this,
-						options = self.options,
-						offsetHeight;
+						options = self.options;
 
 					self.tabIndicatorElement = null;
 					self.tabIndicator = null;
@@ -177,17 +176,6 @@
 					element.classList.add(classes.uiSectionChanger);
 
 					self.scroller.style.position = "absolute";
-					offsetHeight = element.offsetHeight;
-
-					if (offsetHeight === 0) {
-						offsetHeight = element.parentNode.offsetHeight;
-						element.style.height = offsetHeight + "px";
-					}
-
-					self._sectionChangerWidth = element.offsetWidth;
-					self._sectionChangerHeight = offsetHeight;
-					self._sectionChangerHalfWidth = self._sectionChangerWidth / 2;
-					self._sectionChangerHalfHeight = self._sectionChangerHeight / 2;
 					self.orientation = options.orientation === "horizontal" ? Orientation.HORIZONTAL : Orientation.VERTICAL;
 
 					return element;
@@ -270,27 +258,35 @@
 				_prepareLayout: function () {
 					var o = this.options,
 						sectionLength = this.sections.length,
-						width = this._sectionChangerWidth,
-						height = this._sectionChangerHeight,
 						orientation = this.orientation,
 						scrollerStyle = this.scroller.style,
+						offsetHeight = this.element.offsetHeight,
 						tabHeight;
+
+					if (offsetHeight === 0) {
+						offsetHeight = this.element.parentNode.offsetHeight;
+						this.element.style.height = offsetHeight + "px";
+					}
+
+					this._sectionChangerWidth = this.element.offsetWidth;
+					this._sectionChangerHeight = offsetHeight;
+					this._sectionChangerHalfWidth = this._sectionChangerWidth / 2;
+					this._sectionChangerHalfHeight = this._sectionChangerHeight / 2;
 
 					if (o.useTab) {
 						this._initTabIndicator();
 						tabHeight = this.tabIndicatorElement.offsetHeight;
-						height -= tabHeight;
-						this._sectionChangerHalfHeight = height / 2;
-						this.element.style.height = height + "px";
-						this._sectionChangerHeight = height;
+						this._sectionChangerHeight -= tabHeight;
+						this._sectionChangerHalfHeight = this._sectionChangerHeight / 2;
+						this.element.style.height = this._sectionChangerHeight + "px";
 					}
 
 					if (orientation === Orientation.HORIZONTAL) {
-						scrollerStyle.width = (o.fillContent ? width * sectionLength : calculateCustomLayout(orientation, this.sections)) + "px";
-						scrollerStyle.height = height + "px"; //set Scroller width
+						scrollerStyle.width = (o.fillContent ? this._sectionChangerWidth * sectionLength : calculateCustomLayout(orientation, this.sections)) + "px";
+						scrollerStyle.height = this._sectionChangerHeight + "px";
 					} else {
-						scrollerStyle.width = width + "px"; //set Scroller width
-						scrollerStyle.height = (o.fillContent ? height * sectionLength : calculateCustomLayout(orientation, this.sections)) + "px";
+						scrollerStyle.width = this._sectionChangerWidth + "px";
+						scrollerStyle.height = (o.fillContent ? this._sectionChangerHeight * sectionLength : calculateCustomLayout(orientation, this.sections)) + "px";
 					}
 
 				},


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/380

[Problem] SectionChanger resize does not change dimensions of its
		  sections.

[Cause] SectionChanger dimensions are determined in build method which is
		called only once. However, resize on SectionChanger widget results in calling
		refresh() function which reuses outdated SectionChanger dimensions.

[Solution] Update SectionChanger dimensions in _prepareLayout function.

[Test]
	1. Open Mobile Sample in DE.
	2. Add SectionChanger widget.
	3. Resize SectionChanger.
	4. Click outside SectionChanger.
	5. Click on SectionChanger again.
	6. SectionChanger and sections should have the same dimensions.

[Remarks] Wearable Profile in Edit Mode of DE, causes SectionChanger to be expanded
	to 3 * 'its height'. This happens due to two bouncing elements which are
	children of SectionChanger for Wearable. This is done intentionally according to
	'containerExpander' (design-editor-element-utils.js) and is rolled back in preview.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>