### PR TITLE
(mobile) TextInput: fix for postion of clear button icon in search input

### DIFF
--- a/src/css/profile/mobile/changeable/common/textinput.less
+++ b/src/css/profile/mobile/changeable/common/textinput.less
@@ -51,7 +51,6 @@ textarea.ui-text-input {
 				}
 
 				~ .ui-text-input-clear {
-					margin-right: 0;
 					right: 0;
 				}
 
@@ -73,11 +72,6 @@ textarea.ui-text-input {
 				margin: 11 * @unit_base 0 20 * @unit_base 0;
 				position: absolute;
 				width: calc(~"100% - "64 * @unit_base);
-
-			}
-
-			~ .ui-text-input-clear {
-				right: -36 * @unit_base;
 			}
 		}
 	}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/276
[Problem] Search Input: Clear button is moved too much to right
[Solution] Css selectors for clear button position has been changed.
 - new examples has been added for check and prevent regression
(cherry-picked from tau_1.1 branch)

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>