### PR TITLE
(util) globalize: block data loading when data has already exists

### DIFF
--- a/src/js/core/util/globalize.js
+++ b/src/js/core/util/globalize.js
@@ -278,10 +278,12 @@
 				if (!cache[path]) {
 					loadJSON(path).then(function (info) {
 						cache[path] = info;
+						info.fromCache = false;
 						deferred.resolve(info);
 					},
 						deferred.reject);
 				} else {
+					cache[path].fromCache = true;
 					deferred.resolve(cache[path]);
 				}
 				return deferred;
@@ -488,7 +490,9 @@
 							.done(function (locale) {
 								loadCustomData(locale)
 									.then(function (info) {
-										Globalize.loadMessages(info.data);
+										if (!info.fromCache) { // data
+											Globalize.loadMessages(info.data);
+										}
 										globalizeInstance = new Globalize(locale);
 										deferred.resolve(globalizeInstance);
 									}, function () {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/433
[Problem] loaded data are duplicated in Globalize object
[Solution] When data for globalize was loaded before then data
 property 'fromCache' is set to true and data doesn't load again

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>