### PR TITLE
Build SectionChanger widget in circle-helper.js

### DIFF
--- a/examples/wearable/Basic/js/circle-helper.js
+++ b/examples/wearable/Basic/js/circle-helper.js
@@ -2,8 +2,11 @@
 /*jslint unparam: true */
 (function (tau) {
 
+	var tauSectionChanger;
+
 	// This logic works only on circular device.
 	if (tau.support.shape.circle) {
+
 		/**
 		 * pagebeforeshow event handler
 		 * Do preparatory works and adds event listeners
@@ -12,9 +15,11 @@
 			/**
 			 * page - Active page element
 			 * list - NodeList object for lists in the page
+			 * changer - SectionChanger element in the page
 			 */
 			var page,
-				list;
+				list,
+				changer;
 
 			page = event.target;
 			if (page.id !== "page-snaplistview" && page.id !== "page-swipelist" && page.id !== "page-marquee-list") {
@@ -22,7 +27,20 @@
 				if (list) {
 					tau.widget.ArcListview(list);
 				}
+
+				changer = page.querySelector(".ui-section-changer");
+				if (changer) {
+					tauSectionChanger = tau.widget.SectionChanger(changer /* overwrite default options if needed */);
+				}
 			}
+		});
+
+		/**
+		 * pagehide event handler
+		 */
+		document.addEventListener("pagehide", function () {
+			// Release object.
+			tauSectionChanger.destroy();
 		});
 	}
 }(tau));


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/346

[Problem] On Wearable profile, in DE Preview, sections are displayed as list
		and can not be scrolled.
		The same issue occurs if html already contains section changer object
		and DE is opened.

[Cause] SectionChanger is being built only after D&D operation in DE whereas
		while going to Preview, SectionChanger attributes like
		'id', 'data-tau-built' are missing.

[Solution] Build SectionChanger object on pagebeforeshow event in similar
		way to UIComponents app
		https://github.com/Samsung/TAU/blob/tau_1.1/examples/wearable/UIComponents/contents/navcontrols/sectionchanger/hsection.js

[Test]
	0. Apply the patch to WATT/TAU/1.1
	1. Enable SecionChanger by reverting https://github.com/Samsung/TAU-Design-Editor/pull/372
	2. Build DE.
	3. Open TAU Base Application on Wearable.
	4. Add SectionChanger object.
	5. Add more sections by pressing '+' button.
	6. Go to Preview.
	7. Section should be scrolled by mouse click and move on them.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>