### PR TITLE
(examples) UIComponents: fix for webkit date/time inputs appearance

### DIFF
--- a/examples/wearable/UIComponents/contents/etc/index.html
+++ b/examples/wearable/UIComponents/contents/etc/index.html
@@ -52,7 +52,7 @@
 					<div>
 						<span id="webkitui_hiddentime_value">
 						</span>
-						<input id="input_webkitui_hiddentime" style="visibility:hidden; width:50px" type="time" />
+						<input id="input_webkitui_hiddentime" type="time" />
 					</div>
 				</li>
 				<li class="ui-listview-divider">

--- a/examples/wearable/UIComponents/css/style.circle.css
+++ b/examples/wearable/UIComponents/css/style.circle.css
@@ -1096,4 +1096,9 @@ input[type="checkbox"]#checkboxControl {
 
 #page_webkitui input {
 	max-width: 300px;
+	color: initial;
+}
+#input_webkitui_hiddentime {
+	position: absolute;
+	visibility: hidden;
 }


### PR DESCRIPTION
[Issue] N/A
[Problem] webkit date/time inputs have white text on light background
[Solution] Colors in sample app has been changed to contrasting

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>