### PR TITLE
(examples) UIComponents: fix for header height in DatePicker sample

### DIFF
--- a/examples/wearable/UIComponents/contents/controls/date-picker.html
+++ b/examples/wearable/UIComponents/contents/controls/date-picker.html
@@ -18,7 +18,7 @@
 
 <body>
 	<div class="ui-page" data-enable-page-scroll="false" id="date-picker-page">
-		<header class="ui-header ui-header-big">
+		<header class="ui-header ui-header-small">
 			<h2 class="ui-title">
 				Set date
 			</h2>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/405
[Problem] Date Picker - day indicator is overlapped
[Solution] Developer can set diffrent header size, in this case
 good solution is set class "ui-header-small".

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>