### PR TITLE
(core) BaseWidget: fix for converting number options during widget refresh

### DIFF
--- a/examples/wearable/UIComponents/contents/controls/time-picker.html
+++ b/examples/wearable/UIComponents/contents/controls/time-picker.html
@@ -18,7 +18,7 @@
 
 <body>
 	<div class="ui-page" data-enable-page-scroll="false" id="number-picker-page">
-		<header class="ui-header ui-header-big">
+		<header class="ui-header">
 			<h2 class="ui-title">
 				Set alarm
 			</h2>

--- a/src/js/core/widget/BaseWidget.js
+++ b/src/js/core/widget/BaseWidget.js
@@ -353,6 +353,9 @@
 							prefixedValue = getNSData(element, attributeName);
 
 						if (prefixedValue !== null) {
+							if (typeof options[option] === "number") {
+								prefixedValue = parseFloat(prefixedValue);
+							}
 							options[option] = prefixedValue;
 						} else {
 							if (typeof options[option] === "boolean") {

--- a/src/js/profile/wearable/widget/wearable/TimePicker.js
+++ b/src/js/profile/wearable/widget/wearable/TimePicker.js
@@ -227,7 +227,6 @@
 				var self = this,
 					initDate = new Date(),
 					ui = self._ui,
-					uiNumberHours = ui.numberHours,
 					uiInputHours = ui.numberPickerHoursInput;
 
 				//set the initial hours value, based on time stamp
@@ -238,8 +237,6 @@
 				} else {
 					self._maxHour = 12;
 				}
-				uiNumberHours.classList.add(classes.ACTIVE_LABEL);
-				uiNumberHours.classList.add(classes.ACTIVE_LABEL_ANIMATION);
 				self._actualMax = parseInt(uiInputHours.max, 10);
 				self._toggleCircleIndicator();
 				// move indicator to the selected hours value


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/406
[Problem] Time Picker - Only Hours can be changed with rotarydetent event
[Solution] Bug in refresh method of base widget caused wrong running of
 time picker because of number value of "to" was converted to string.
 Additionally was fixed header size of TimePicker example and disabled
 `active` style of Hours on widget start.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>