### PR TITLE
[Wearable] Replace "change" event with "input" for Slider

### DIFF
--- a/examples/wearable/UIComponents/contents/controls/dimmer.js
+++ b/examples/wearable/UIComponents/contents/controls/dimmer.js
@@ -10,7 +10,7 @@
 	pageBeforeShowHandler = function () {
 		slider = tau.widget.Slider(elSlider);
 		dimmer = tau.widget.Dimmer(elDimmer);
-		elSlider.addEventListener("change", onInput, false);
+		elSlider.addEventListener("input", onInput, false);
 	};
 
 	function onInput(event) {

--- a/examples/wearable/UIComponents/contents/controls/slider/extended_slider.js
+++ b/examples/wearable/UIComponents/contents/controls/slider/extended_slider.js
@@ -25,7 +25,7 @@
 	 */
 	pageBeforeShowHandler = function () {
 		slider = tau.widget.Slider(elSlider);
-		elSlider.addEventListener("change", changeOpacity, false);
+		elSlider.addEventListener("input", changeOpacity, false);
 	};
 
 	/**
@@ -34,7 +34,7 @@
 	 */
 	pageHideHandler = function () {
 		slider.destroy();
-		elSlider.removeEventListener("change", changeOpacity, false);
+		elSlider.removeEventListener("input", changeOpacity, false);
 	};
 
 	page.addEventListener("pagebeforeshow", pageBeforeShowHandler, false);

--- a/src/js/profile/wearable/widget/wearable/Slider.js
+++ b/src/js/profile/wearable/widget/wearable/Slider.js
@@ -65,11 +65,11 @@
 				prototype = new CoreSlider(),
 				eventType = {
 					/**
-					 * Triggered when the section is changed.
-					 * @event change
+					 * Triggered when the slider value is changed.
+					 * @event input
 					 * @member ns.widget.wearable.Slider
 					 */
-					CHANGE: "change"
+					INPUT: "input"
 				},
 				/**
 				* Standard slider widget
@@ -520,7 +520,7 @@
 						self._ui.valueField.textContent = value;
 					}
 					if (value !== currentValue) {
-						self.trigger(eventType.CHANGE);
+						self.trigger(eventType.INPUT);
 					}
 				} else {
 					return CoreSliderPrototype._setValue.call(self, value);


### PR DESCRIPTION
[Issue] N/A

[Problem] Mobile profile successfully emits both events
	"input" and "change" on Slider widget whereas Wearable profile
	emits only "change".

[Solution] Emits "input" event instead of "change" since according to [1]
	input event should be fired immediately when the slider is adjusted but
	change event does not fire immediately, the value does not change until
	the slider stops moving
	This fixes SThing.js behaviour with Slider and Dimmer synchronization
	for Wearable.

[Remarks] May cause regression for tau apps already using "change" event.
	To fix this we should provide real implementation for "change" event.

[1] https://www.impressivewebs.com/onchange-vs-oninput-for-range-sliders/

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>