### PR TITLE
PageContainer: fix for options object delivered to the change method

### DIFF
--- a/src/js/core/widget/core/PageContainer.js
+++ b/src/js/core/widget/core/PageContainer.js
@@ -173,6 +173,7 @@
 
 					toPageElement.classList.add(classes.uiBuild);
 
+					delete options.url;
 					toPageWidget = engine.instanceWidget(toPageElement, calculatedOptions.widget, options);
 
 					// set sizes of page for correct display


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/450
[Problem] UIComponents: Back the top of page when click back
[Solution] The change method allows to provide object of options,
 but when object contains url property this cause confusion in routing

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>