### PR TITLE
Invoke init method with scrolled element

### DIFF
--- a/src/js/core/widget/core/scroller/scrollbar/ScrollBar.js
+++ b/src/js/core/widget/core/scroller/scrollbar/ScrollBar.js
@@ -148,7 +148,7 @@
 				var self = this;
 
 				self._clear();
-				self._init();
+				self._init(self.element);
 				self.translate(self.lastScrollPosition);
 			};
 


### PR DESCRIPTION
[Issue] N/A
[Problem]
Section changer was not working properly after restoring app.
[Reason]
When app with section changer was restored,
refresh method was called invoking init without scrolled element
[Solution]
Call init with scrolled element as argument.
