### PR TITLE
(wearable) Spin: added widget example for using in public api

### DIFF
--- a/examples/wearable/UIComponents/contents/controls/index.html
+++ b/examples/wearable/UIComponents/contents/controls/index.html
@@ -91,6 +91,11 @@
 					</a>
 				</li>
 				<li>
+					<a href="spin/index.html">
+						Spin
+					</a>
+				</li>
+				<li>
 					<a href="numberpicker/index.html">
 						Number Picker
 					</a>

--- a/examples/wearable/UIComponents/contents/controls/spin/custom-spin.html
+++ b/examples/wearable/UIComponents/contents/controls/spin/custom-spin.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta name="viewport" content="width=device-width,user-scalable=no"/>
+	<title>Tizen Web IDE - Template - Tizen Web UI Framework - Spin</title>
+
+	<link rel="stylesheet"
+			href="../../../lib/tau/wearable/theme/default/tau.css">
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
+			href="../../../lib/tau/wearable/theme/default/tau.circle.min.css">
+	<link rel="stylesheet" href="../../../css/style.css">
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
+			href="../../../css/style.circle.css">
+</head>
+
+<body>
+	<!-- Start of page: #one -->
+	<div class="ui-page ui-page-active" id="custom-spin-page" data-enable-page-scroll="false">
+		<style>
+			.custom-spin {
+				height: 120px;
+				width: 150px;
+				font-size: 40px;
+			}
+			.custom-spin .ui-spin-item {
+				color: orangered;
+			}
+			.custom-spin .ui-spin-item-selected {
+				font-size: 40px;
+				color: white;
+			}
+		</style>
+		<header class="ui-header ui-header-smaller">
+			<h2 class="ui-title">Spin</h2>
+		</header>
+		<div class="ui-content">
+			<div id="descriptions">default</div>
+			<div class="ui-spin custom-spin"
+				data-min="0"
+				data-max="11"
+				data-labels="Jan,Feb,Mar,Apr,May,June,July,Aug,Sept,Oct,Nov,Dec"
+				data-value="5"
+				data-duration="600"
+				data-loop="enabled"
+				data-momentum-level="0"
+				data-roll-height="item">
+			</div>
+		</div>
+		<footer class="ui-footer ui-bottom-button ui-fixed">
+			<button class="ui-btn">Change</button>
+		</footer>
+		<script type="text/javascript" src="./js/custom-spin.js"></script>
+	</div><!-- /page one -->
+</body>
+<script type="text/javascript" src="../../../lib/tau/wearable/js/tau.js"></script>
+</html>

--- a/examples/wearable/UIComponents/contents/controls/spin/default-spin.html
+++ b/examples/wearable/UIComponents/contents/controls/spin/default-spin.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta name="viewport" content="width=device-width,user-scalable=no"/>
+	<title>Tizen Web IDE - Template - Tizen Web UI Framework - Spin</title>
+
+	<link rel="stylesheet"
+			href="../../../lib/tau/wearable/theme/default/tau.css">
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
+			href="../../../lib/tau/wearable/theme/default/tau.circle.min.css">
+	<link rel="stylesheet" href="../../../css/style.css">
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
+			href="../../../css/style.circle.css">
+</head>
+
+<body>
+	<!-- Start of page: #one -->
+	<div class="ui-page ui-page-active" id="default-spin-page" data-enable-page-scroll="false">
+		<style>
+			.default-spin {
+				height: 120px;
+				font-size: 50px;
+			}
+			.default-spin .ui-spin-item-selected {
+				font-size: 50px;
+			}
+		</style>
+  	    <header class="ui-header ui-header-smaller">
+			<h2 class="ui-title">Spin</h2>
+		</header>
+		<div class="ui-content">
+			<div id="descriptions">default</div>
+			<div class="ui-spin default-spin"
+				data-min="0"
+				data-max="9"
+				data-value="3"
+				data-loop="enabled"
+				data-roll-height="custom"
+				data-item-height="30"
+				data-duration="500">
+			</div>
+		</div>
+		<footer class="ui-footer ui-bottom-button ui-fixed">
+			<button class="ui-btn">Change</button>
+		</footer>
+		<script type="text/javascript" src="./js/default-spin.js"></script>
+	</div><!-- /page one -->
+</body>
+<script type="text/javascript"
+				src="../../../lib/tau/wearable/js/tau.js"></script>
+</html>

--- a/examples/wearable/UIComponents/contents/controls/spin/index.html
+++ b/examples/wearable/UIComponents/contents/controls/spin/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta name="viewport" content="width=device-width,user-scalable=no"/>
+	<title>Tizen Web IDE - Template - Tizen Web UI Framework - Spin</title>
+	<link rel="stylesheet" href="../../../lib/tau/wearable/theme/default/tau.css">
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
+		  href="../../../lib/tau/wearable/theme/default/tau.circle.min.css">
+	<link rel="stylesheet" href="../../../css/style.css">
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
+		  href="../../../css/style.circle.css">
+</head>
+
+<body>
+	<!-- Start of page: #one -->
+	<div class="ui-page ui-page-active" id="spin-examples-page">
+		<header class="ui-header">
+			<h2 class="ui-title">Spin</h2>
+		</header>
+		<div class="ui-content">
+			<ul class="ui-listview">
+				<li><a href="./default-spin.html">Default</a></li>
+				<li><a href="./custom-spin.html">Custom</a></li>
+				<li><a href="./spin-group.html">Spin group</a></li>
+			</ul>
+		</div>
+	</div><!-- /page one -->
+</body>
+<script type="text/javascript"
+				src="../../../lib/tau/wearable/js/tau.js"></script>
+</html>

--- a/examples/wearable/UIComponents/contents/controls/spin/js/custom-spin.js
+++ b/examples/wearable/UIComponents/contents/controls/spin/js/custom-spin.js
@@ -1,0 +1,118 @@
+(function (window) {
+	"use strict";
+
+	var page = document.getElementById("custom-spin-page"),
+		content = page.querySelector(".ui-content"),
+		descriptions = document.getElementById("descriptions"),
+		element = page.querySelector(".ui-spin"),
+		spin = null,
+		stage = 0;
+
+	function onClickChange() {
+		// Jan,Feb,Mar,Apr,May,June,July,Aug,Sept,Oct,Nov,Dec
+		switch (stage) {
+			case 0 :
+				descriptions.innerHTML = ".value(1) label Feb";
+				spin.value(1);
+				break;
+			case 1 :
+				descriptions.innerHTML = ".value(2) label Mar";
+				spin.value(2);
+				break;
+			case 2 :
+				descriptions.innerHTML = ".value(5) label June";
+				spin.value(5);
+				break;
+			case 3 :
+				descriptions.innerHTML = ".value(10) label Nov";
+				spin.value(10);
+				break;
+		}
+		if (++stage > 3) {
+			stage = 0;
+		}
+	}
+
+	function onRotary(ev) {
+		var step = 1;
+
+		// get spin widget instance
+		spin = window.tau.widget.Spin(element);
+
+		if (spin.option("enabled")) {
+			if (ev.detail.direction === "CW") {
+				spin.value(spin.value() + step);
+			} else {
+				spin.value(spin.value() - step);
+			}
+			descriptions.innerHTML = ".value(" + spin.value() + ")";
+		}
+	}
+
+	function onClick(ev) {
+		var tau = window.tau;
+
+		// get spin widget instance
+		spin = window.tau.widget.Spin(element);
+
+		if (tau.util.selectors.getClosestBySelector(ev.target, ".ui-spin") === null) {
+			// click on background
+			spin.option("enabled", false);
+		} else {
+			// Disable spin on click on selected item
+			if (!spin.option("enabled")) {
+				spin.option("enabled", true);
+			} else if (ev.target.classList.contains("ui-spin-item-selected")) {
+				spin.option("enabled", false);
+			}
+		}
+	}
+
+	/**
+	 * Template initializing
+	 */
+	function init() {
+		page.addEventListener("pageshow", function () {
+			var tau = window.tau;
+
+			// create spin widget
+			spin = tau.widget.Spin(element);
+
+			// enable spin on click
+			content.addEventListener("vclick", onClick);
+
+			element.addEventListener("spinchange", function () {
+				/*
+				Event "spinchange" is not triggering when value is changing by .value() method.
+				eg. "rotarydetent" does not trigger "spinchange" because of value
+				    has changed by .value()
+				*/
+				descriptions.innerHTML = "on spinchange: " + spin.value();
+			});
+
+			element.addEventListener("spinstep", function () {
+				//console.log("spinstep");
+			});
+
+			// Spin widget doesn't have inner support for rotary event
+			// add rotary event
+			document.addEventListener("rotarydetent", onRotary);
+
+			// cleanup widget in order to avoid memory leak
+			tau.event.one(page, "pagehide", function () {
+				document.removeEventListener("rotarydetent", onRotary);
+				document.querySelector(".ui-footer .ui-btn")
+					.removeEventListener("click", onClickChange);
+				content.removeEventListener("vclick", onClick);
+				spin.destroy();
+			});
+		});
+
+		document.querySelector(".ui-footer .ui-btn")
+			.addEventListener("click", onClickChange);
+	}
+
+	// init application
+	init();
+
+})(window);

--- a/examples/wearable/UIComponents/contents/controls/spin/js/default-spin.js
+++ b/examples/wearable/UIComponents/contents/controls/spin/js/default-spin.js
@@ -1,0 +1,117 @@
+(function (window) {
+	"use strict";
+
+	var page = document.getElementById("default-spin-page"),
+		descriptions = document.getElementById("descriptions"),
+		content = page.querySelector(".ui-content"),
+		element = page.querySelector(".ui-spin"),
+		spin = null,
+		stage = 0;
+
+	function onClickChange() {
+		switch (stage) {
+			case 0 :
+				descriptions.innerHTML = ".value(9)";
+				spin.value(9);
+				break;
+			case 1 :
+				descriptions.innerHTML = ".value(5)";
+				spin.value(5);
+				break;
+			case 2 :
+				descriptions.innerHTML = ".value(0)";
+				spin.value(0);
+				break;
+		}
+		if (++stage > 2) {
+			stage = 0;
+		}
+	}
+
+	function onRotary(ev) {
+		var step = 1;
+
+		// get spin widget instance
+		spin = window.tau.widget.Spin(element);
+
+		if (spin.option("enabled")) {
+			if (ev.detail.direction === "CW") {
+				spin.value(spin.value() + step);
+			} else {
+				spin.value(spin.value() - step);
+			}
+			descriptions.innerHTML = ".value(" + spin.value() + ")";
+		}
+	}
+
+	function onClick(ev) {
+		var tau = window.tau;
+
+		// get spin widget instance
+		spin = window.tau.widget.Spin(element);
+
+		if (tau.util.selectors.getClosestBySelector(ev.target, ".ui-spin") === null) {
+			// click on background
+			spin.option("enabled", false);
+		} else {
+			// Disable spin on click on selected item
+			if (!spin.option("enabled")) {
+				spin.option("enabled", true);
+			} else if (ev.target.classList.contains("ui-spin-item-selected")) {
+				spin.option("enabled", false);
+			}
+		}
+	}
+
+	/**
+	 * Template initializing
+	 */
+	function init() {
+		page.addEventListener("pageshow", function () {
+			var tau = window.tau;
+
+			// create range indicator widget
+			spin = tau.widget.Spin(element, {
+				min: 0,
+				max: 9
+			});
+
+			// enable spin on click
+			content.addEventListener("vclick", onClick);
+
+			element.addEventListener("spinchange", function () {
+				/*
+				Event "spinchange" is not triggering when value is changing by .value() method.
+				eg. "rotarydetent" does not trigger "spinchange" because of value
+				    has changed by .value()
+				 */
+				descriptions.innerHTML = "on spinchange: " + spin.value();
+			});
+
+			element.addEventListener("spinstep", function () {
+				//console.log("spinstep");
+			});
+
+			// Spin widget doesn't have inner support for rotary event
+			// add rotary event
+			document.addEventListener("rotarydetent", onRotary);
+
+			// cleanup widget in order to avoid memory leak
+			tau.event.one(page, "pagehide", function () {
+				document.removeEventListener("rotarydetent", onRotary);
+				document.querySelector(".ui-footer .ui-btn")
+					.removeEventListener("click", onClick);
+				content.removeEventListener("vclick", onClick);
+
+				spin.destroy();
+			});
+		});
+
+		document.querySelector(".ui-footer .ui-btn")
+			.addEventListener("click", onClickChange);
+	}
+
+	// init application
+	init();
+
+})(window);

--- a/examples/wearable/UIComponents/contents/controls/spin/js/spin-group.js
+++ b/examples/wearable/UIComponents/contents/controls/spin/js/spin-group.js
@@ -1,0 +1,100 @@
+(function (window) {
+	"use strict";
+
+	var page = document.getElementById("spin-group-page"),
+		digit1 = document.getElementById("digit-1"),
+		digit2 = document.getElementById("digit-2"),
+		digit3 = document.getElementById("digit-3"),
+		spins = [];
+
+	function toggleSpins(target) {
+		var tau = window.tau,
+			spinElement = tau.util.selectors
+				.getClosestBySelector(target, ".ui-spin"),
+			// get widget instance
+			spin = tau.widget.Spin(spinElement);
+
+		if (spin) {
+			// Disable spin on click on selected item
+			if (!spin.option("enabled")) {
+				spin.option("enabled", true);
+			} else if (target.classList.contains("ui-spin-item-selected")) {
+				spin.option("enabled", false);
+			}
+
+			// disble previous enbled spin
+			spins.forEach(function (toDisable) {
+				if (toDisable !== spin) {
+					toDisable.option("enabled", false);
+				}
+			});
+		}
+	}
+
+	function onClick(ev) {
+		toggleSpins(ev.target);
+	}
+
+	function onRotary(ev) {
+		var step = 1,
+			// find enabled spin
+			spin = spins.filter(function (spin) {
+				return spin.option("enabled");
+			})[0];
+
+		if (spin && spin.option("enabled")) {
+			if (ev.detail.direction === "CW") {
+				spin.value(spin.value() + step);
+			} else {
+				spin.value(spin.value() - step);
+			}
+		}
+	}
+
+	/**
+	 * Template initializing
+	 */
+	function init() {
+		page.addEventListener("pageshow", function () {
+			var tau = window.tau;
+
+			// create range indicator widget
+			spins[0] = tau.widget.Spin(digit1);
+			spins[1] = tau.widget.Spin(digit2);
+			spins[2] = tau.widget.Spin(digit3);
+
+			// enable spin on click
+			document.addEventListener("vclick", onClick);
+
+			document.addEventListener("spinchange", function () {
+				//console.log("spinchange");
+				/*
+				Event "spinchange" is not triggering when value is changing by .value() method.
+				eg. "rotarydetent" does not trigger "spinchange" because of value
+				    has changed by .value()
+				 */
+			}, true);
+
+			document.addEventListener("spinstep", function () {
+				//console.log("spinstep");
+			}, true);
+
+			// Spin widget doesn't have inner support for rotary event
+			// add rotary event
+			document.addEventListener("rotarydetent", onRotary);
+
+			// cleanup widget in order to avoid memory leak
+			tau.event.one(page, "pagehide", function () {
+				document.removeEventListener("vclick", onClick);
+				document.removeEventListener("rotarydetent", onRotary);
+				spins.forEach(function (spin) {
+					spin.destroy();
+				});
+			});
+		});
+	}
+
+	// init application
+	init();
+
+})(window);

--- a/examples/wearable/UIComponents/contents/controls/spin/spin-group.html
+++ b/examples/wearable/UIComponents/contents/controls/spin/spin-group.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta name="viewport" content="width=device-width,user-scalable=no"/>
+	<title>Tizen Web IDE - Template - Tizen Web UI Framework - Spin</title>
+
+	<link rel="stylesheet"
+			href="../../../lib/tau/wearable/theme/default/tau.css">
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
+			href="../../../lib/tau/wearable/theme/default/tau.circle.min.css">
+	<link rel="stylesheet" href="../../../css/style.css">
+	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
+			href="../../../css/style.circle.css">
+</head>
+
+<body>
+	<!-- Start of page: #one -->
+	<div class="ui-page ui-page-active" id="spin-group-page" data-enable-page-scroll="false">
+		<style>
+			.ui-spin {
+				height: 160px;
+				font-size: 80px;
+				width: 46px;
+			}
+			.ui-spin .ui-spin-item-selected {
+				font-size: 80px;
+			}
+			.ui-spin .ui-spin-item {
+				height: 80px;
+			}
+		</style>
+  	    <header class="ui-header ui-header-smaller">
+			<h2 class="ui-title">Spin</h2>
+		</header>
+		<div class="ui-content">
+			<div id="descriptions">group</div>
+			<div class="ui-spin" id="digit-3"
+				data-min="0"
+				data-max="9"
+				data-value="0"
+				data-loop="enabled"
+				data-roll-height="custom"
+				data-item-height="80"
+				data-move-factor="0.55"
+				data-scale-factor="0.50"
+				data-duration="500">
+			</div>
+			<div class="ui-spin" id="digit-2"
+				data-min="0"
+				data-max="9"
+				data-value="0"
+				data-loop="enabled"
+				data-roll-height="custom"
+				data-item-height="80"
+				data-move-factor="0.55"
+				data-scale-factor="0.50"
+				data-duration="500">
+			</div>
+			<div class="ui-spin" id="digit-1"
+				data-min="0"
+				data-max="9"
+				data-value="0"
+				data-loop="enabled"
+				data-roll-height="custom"
+				data-item-height="80"
+				data-move-factor="0.55"
+				data-scale-factor="0.50"
+				data-duration="500">
+			</div>
+		</div>
+		<script type="text/javascript" src="./js/spin-group.js"></script>
+	</div><!-- /page one -->
+</body>
+<script type="text/javascript"
+				src="../../../lib/tau/wearable/js/tau.js"></script>
+</html>

--- a/src/js/core/widget/BaseWidget.js
+++ b/src/js/core/widget/BaseWidget.js
@@ -211,6 +211,7 @@
 				 */
 				TYPE_FUNCTION = "function",
 				TYPE_STRING = "string",
+				DEFAULT_STRING_DELIMITER = ",",
 				disableClass = "ui-state-disabled",
 				ariaDisabled = "aria-disabled",
 				__callbacks;
@@ -344,7 +345,8 @@
 			prototype._getCreateOptions = function (element) {
 				var self = this,
 					options = self.options,
-					tag = element.localName.toLowerCase();
+					tag = element.localName.toLowerCase(),
+					delimiter;
 
 				if (options) {
 					Object.keys(options).forEach(function (option) {
@@ -355,6 +357,11 @@
 						if (prefixedValue !== null) {
 							if (typeof options[option] === "number") {
 								prefixedValue = parseFloat(prefixedValue);
+							} else if (typeof options[option] === "object" &&
+										typeof prefixedValue === "string" &&
+										Array.isArray(options[option])) {
+								delimiter = element.dataset.delimiter || DEFAULT_STRING_DELIMITER;
+								prefixedValue = prefixedValue.split(delimiter);
 							}
 							options[option] = prefixedValue;
 						} else {

--- a/src/js/profile/wearable/widget/wearable/Spin.js
+++ b/src/js/profile/wearable/widget/wearable/Spin.js
@@ -71,8 +71,27 @@
 					/**
 					 * Object with default options
 					 * @property {Object} options
-					 * @property {Object} [options.type] Spin type
-					 * @property {number} [options.orientation] orientation
+					 * @property {number} options.min minimum value of spin
+					 * @property {number} options.max maximum value of spin
+					 * @property {number} options.step step of decrease / increase value
+					 * @property {string} [options.moduloValue="enabled"] value will be show as modulo
+					 *  // if enabled then value above max will be show as modulo eg. 102
+					 *  // with range 0-9 will be show as 2 (12 % 10)
+					 * @property {string} [options.shortPath="enabled"] spin rotate with short path
+					 *  // eg. when value will be 1 and then will change to 8
+					 *  // the spin will rotate by 1 -> 0 -> 9 -> 0
+					 * @property {number} [options.duration=ROLL_DURATION] time of rotate to indicated value
+					 * @property {string} [options.direction="up"] direction of spin rotation
+					 * @property {string} [options.rollHeight="container"] size of frame to rotate one item
+					 * @property {number} [options.itemHeight=38] size of frame for "custom" rollHeight
+					 * @property {number} [options.momentumLevel=0] define moementum level on drag
+					 * @property {number} [options.scaleFactor=0.4] second / next items scale factor
+					 * @property {number} [options.moveFactor=0.4] second / next items move factor from center
+					 * @property {number} [options.loop="enabled"] when the spin reaches max value then loops to min value
+					 * @property {string} [options.labels=""] defines labels for values likes days of week separated by ","
+					 * // eg. "Monday,Tuesday,Wednesday"
+					 * @property {string} [options.digits=0] value filling with zeros, eg. 002 for digits=3;
+					 * // eg. "Monday,Tuesday,Wednesday"
 					 * @member ns.widget.wearable.Spin
 					 */
 					this.options = {
@@ -90,7 +109,8 @@
 						moveFactor: 0.4,
 						loop: "enabled",
 						labels: [],
-						digits: 0 // 0 - doesn't complete by zeros
+						digits: 0, // 0 - doesn't complete by zeros
+						value: 0
 					};
 					this._ui = {};
 					this.length = this.options.max - this.options.min + 1;
@@ -419,6 +439,9 @@
 							}
 						}
 						self.options.value = value;
+						// set data-value on element
+						self.element.dataset.value = value;
+
 						// stop previous animation
 						animation = self.state.animation[0];
 						if (animation !== null && animation.to !== animation.current) {

--- a/tests/js/profile/wearable/widget/wearable/CircularIndexScrollbar/circularindexscrollbar.js
+++ b/tests/js/profile/wearable/widget/wearable/CircularIndexScrollbar/circularindexscrollbar.js
@@ -1,9 +1,10 @@
+/* global equal, test, ok, tau */
 (function (window, document) {
 	"use strict";
 
 	module("profile/wearable/widget/wearable/CircularIndexScrollbar");
 
-	test("circularindexscrollbar class check", 3, function() {
+	test("circularindexscrollbar class check", 3, function () {
 		var el = document.getElementById("widget4"),
 			widget = tau.widget.CircularIndexScrollbar(el);
 
@@ -13,7 +14,7 @@
 		widget.destroy();
 	});
 
-	test("basic attributes test", 6, function() {
+	test("basic attributes test", 6, function () {
 		var el1 = document.getElementById("widget1"),
 			el2 = document.getElementById("widget2"),
 			widget1 = tau.widget.CircularIndexScrollbar(el1),
@@ -24,12 +25,12 @@
 		equal(widget1.options.index[1], "B", "Second index is 'B'");
 		equal(widget1.options.index[2], "C", "Third index is 'C'");
 		equal(widget1.options.index[3], "D", "Forth index is 'D'");
-		equal(widget2.options.index.length, 6, "Indices was seperated by data-delimeter");
+		equal(widget2.options.index.length, 6, "Indices was seperated by data-delimiter");
 		widget1.destroy();
 		widget2.destroy();
 	});
 
-	test("change option test", 1, function() {
+	test("change option test", 1, function () {
 		var el = document.getElementById("widget3"),
 			widget = tau.widget.CircularIndexScrollbar(el);
 
@@ -39,7 +40,7 @@
 		widget.destroy();
 	});
 
-	test("set/get value test", 1, function() {
+	test("set/get value test", 1, function () {
 		var el = document.getElementById("widget4"),
 			widget = tau.widget.CircularIndexScrollbar(el);
 


### PR DESCRIPTION
[Issue] N/A
[Problem] Pickers delivered by TAU are not enough for developers.
 Developers need more customizable widget similar to pickers.
[Solution]
 Spin widget was created for internal usage as common widget for
 NumberPicker, DatePicker, TimePicker. This commit added example
 how to use Spin widget stand alone.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>