### PR TITLE
fix: clean up buttons on widget destroy for extended slider on wearables

### DIFF
--- a/dist/wearable/js/tau.js
+++ b/dist/wearable/js/tau.js
@@ -30405,6 +30405,20 @@ function pathToRegexp (path, keys, options) {
 			};
 
 			/**
+			 * remove buttons for slider
+			 * @method _removeButtons
+			 * @protected
+			 * @param {HTMLElement} element
+			 * @member ns.widget.wearable.Slider
+			 */
+			prototype._removeButtons = function (element) {
+				var buttonsContainer = document.querySelector("div .ui-slider-buttons");
+				if (buttonsContainer != undefined){
+					buttonsContainer.remove();					
+				}
+			};			
+
+			/**
 			 * Build Slider widget
 			 * @method _build
 			 * @protected
@@ -30781,7 +30795,8 @@ function pathToRegexp (path, keys, options) {
 					self.element.style.display = "inline-block";
 
 					CircleProgressBarPrototype._destroy.call(self);
-
+					
+					self._removeButtons();
 					self._ui = null;
 					self.options = null;
 


### PR DESCRIPTION
[Problem] 
Extended slider on wearable does't clean up buttons on widget destroy. Thus each time the widget is recreated new buttons appear and finally buttons are cloned as many times as the widget has been created.

Steps for reproducing the issue:
1) HTML

> 
	<div class="ui-page" id="extendedSliderPage">
		<div class="ui-content ui-content-padding">
			<input type="range" class="ui-slider" id="extendedSlider" name="circleSlider"
						 max="10" data-buttons="true"/>
			<div class="ui-slider-icon" id="slider-icon" style="opacity: 0.5"></div>
			<div class="ui-slider-title">Slider name</div>
			<div class="ui-slider-subtitle">Description</div>
		</div>
	</div>

2) JavaScript
> 
	function attach (pageId) {
	
		var pageIdToUse = getPageIdToUse(pageId);
		page = document.getElementById(pageIdToUse);
		if (page != undefined && page!= null){
			extendedSlider = page.querySelector("#" + widgetName);
			if (extendedSlider!= null && extendedSlider!= null){
				console.log(widgetName + "-attach(): attaching to page id " + "[" + pageIdToUse+ "]" );
				extendedSliderComponent = tau.widget.Slider(extendedSlider,{"thickness":3});
			}else{
				console.log(widgetName + "-attach(): no " + extendedSlider + " to attach on page id" + "[" + pageIdToUse + "]"  );
			}
		}
		
	}

Here below a screenshot of a widget created 3 times (browser load/unload page)
![image](https://user-images.githubusercontent.com/12600222/68071067-86243980-fd76-11e9-95e9-89d0b0ae307c.png)
