### PR TITLE
_restoreContentStyle - restore only non-empty values

### DIFF
--- a/src/js/core/widget/core/Page.js
+++ b/src/js/core/widget/core/Page.js
@@ -499,7 +499,9 @@
 					contentStyle = content ? content.style : {};
 
 				contentStyleAttributes.forEach(function (name) {
-					contentStyle[name] = initialContentStyle[name];
+					if (initialContentStyle[name]) {
+						contentStyle[name] = initialContentStyle[name];
+					}
 				});
 			};
 


### PR DESCRIPTION
[Problem] _restoreContentStyle was resettig Pages' height with empty
value
[Solution] add check verifying if value that is being restored is not
empty

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>