### PR TITLE
Util: _loop method provides loop Time for current animation frame

### DIFF
--- a/src/js/core/util.js
+++ b/src/js/core/util.js
@@ -72,7 +72,7 @@
 				waitingFrames = [];
 
 				while (currentFrameFunction) {
-					currentFrameFunction();
+					currentFrameFunction(loopTime);
 					if (performance.now() - loopTime < 15) {
 						currentFrameFunction = loopWaitingFrames.shift();
 					} else {


### PR DESCRIPTION
[Issue] N/A
[Problem] Progress bar is not animating on value change
[Solution] Animation callback in the progress bar
 expects time as argument but not given.
 The "_loop" method in tau.util has been changed.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>