### PR TITLE
Define the value of the Toggle elements as a number

### DIFF
--- a/src/js/profile/mobile/widget/mobile/ToggleSwitch.js
+++ b/src/js/profile/mobile/widget/mobile/ToggleSwitch.js
@@ -381,8 +381,11 @@
 				var self = this,
 					element = self.element;
 
-				return self._type === "input" ?
-					parseFloat(element.value) : element.selectedIndex;
+				if (["checkbox", "radio"].indexOf(element.type) > -1) {
+					return (element.checked) ? 1 : 0;
+				}
+
+				return element.selectedIndex;
 			};
 
 			/**


### PR DESCRIPTION
- Toggle elements already added have an initial value of undefined.
- Set to 0 when undefined.
- Set 1 to on and 0 to off when clicking on Toggle elements.

Signed-off-by: DoHyung Lim <delight.lim@samsung.com>