### PR TITLE
Fix resetting marquee element

### DIFF
--- a/src/js/core/widget/BaseWidget.js
+++ b/src/js/core/widget/BaseWidget.js
@@ -1127,14 +1127,8 @@
 				}
 			}
 
-			function render(stateObject, element, isChild, options) {
-				var recalculate = false,
-					animation = (options) ? options.animation : null;
-
-				if (animation && !animation.active) {
-					// Animation has stopped before render
-					return false;
-				}
+			function render(stateObject, element, isChild) {
+				var recalculate = false;
 
 				if (stateObject.classList !== undefined) {
 					slice.call(element.classList).forEach(function renderRemoveClassList(className) {
@@ -1171,10 +1165,10 @@
 					element = self.element,
 					animation = self._animation;
 
-				if (now) {
-					render(stateDOM, element, false, {animation: animation});
+				if (now === true) {
+					render(stateDOM, element, false);
 				} else {
-					util.requestAnimationFrame(render.bind(null, stateDOM, element, false, {animation: animation}));
+					util.requestAnimationFrame(render.bind(null, stateDOM, element, false));
 				}
 			};
 

--- a/src/js/core/widget/core/Marquee.js
+++ b/src/js/core/widget/core/Marquee.js
@@ -647,7 +647,7 @@
 				this.option("animation", "stopped");
 				stateDOM.style.webkitMaskImage = (this.options.ellipsisEffect === "none") ? "" : GRADIENTS.RIGHT;
 				stateDOM.children[0].style.webkitTransform = "translateX(0)";
-				self._render();
+				self._render(true);
 			};
 
 			Marquee.prototype = prototype;

--- a/tests/js/core/widget/core/Marquee/Marquee.js
+++ b/tests/js/core/widget/core/Marquee/Marquee.js
@@ -388,6 +388,23 @@
 					}
 				]
 			};
+
+			marquee.element = {
+				style: {
+					webkitMaskImage: ""
+				},
+
+				children: [
+					{
+						style: {
+							webkitTransform: ""
+						}
+					}
+				],
+
+				setAttribute: function () {}
+			}
+
 			marquee.stop = function () {
 				assert.ok(true, "stop was called");
 			};


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/475
[Problem] Marquee widget was not resetting completly.
[Solution] Remove check for render method if animation is active.
           This check should not exist, because widget that has
           paused animation may want to be redrawn at any moment.

This change will not cause regression with https://github.com/Samsung/TAU/issues/239 issue
(ListView now is destroying Marquee widget after element is no longer selected)

Signed-off-by: Pawel Kaczmarczyk <p.kaczmarczy@samsung.com>