### PR TITLE
 Fix headers sections with proper TAU references 

### DIFF
--- a/examples/mobile/UIComponents/components/graphs/bar_graph.html
+++ b/examples/mobile/UIComponents/components/graphs/bar_graph.html
@@ -3,6 +3,8 @@
 <head>
 	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.css">
 	<link rel="stylesheet" href="../../css/style.css">
+	<script src="../../lib/tau/mobile/js/tau.js">
+	</script>
 </head>
 <body>
 <div class="ui-page" id="bar-graph-page">

--- a/examples/mobile/UIComponents/components/graphs/dynamic_graph.html
+++ b/examples/mobile/UIComponents/components/graphs/dynamic_graph.html
@@ -3,6 +3,8 @@
 <head>
 	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.css">
 	<link rel="stylesheet" href="../../css/style.css">
+	<script src="../../lib/tau/mobile/js/tau.js">
+	</script>
 </head>
 <body>
 <div class="ui-page" id="dynamic-graph-page">

--- a/examples/mobile/UIComponents/components/graphs/index.html
+++ b/examples/mobile/UIComponents/components/graphs/index.html
@@ -3,6 +3,8 @@
 <head>
 	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.min.css">
 	<link rel="stylesheet" href="../../css/style.css">
+	<script src="../../lib/tau/mobile/js/tau.js">
+	</script>
 </head>
 <body>
 <div class="ui-page">

--- a/examples/mobile/UIComponents/components/graphs/static_graph.html
+++ b/examples/mobile/UIComponents/components/graphs/static_graph.html
@@ -3,6 +3,8 @@
 <head>
 	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.css">
 	<link rel="stylesheet" href="../../css/style.css">
+	<script src="../../lib/tau/mobile/js/tau.js">
+	</script>
 </head>
 <body>
 <div class="ui-page" id="static-graph-page">

--- a/examples/wearable/UIComponents/contents/controls/dimmer.html
+++ b/examples/wearable/UIComponents/contents/controls/dimmer.html
@@ -3,12 +3,14 @@
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
 	<title>Wearable UI</title>
-	<link rel="stylesheet" href="../../../lib/tau/wearable/theme/default/tau.css">
+	<link rel="stylesheet" href="../../lib/tau/wearable/theme/default/tau.css">
 	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
-		  href="../../../lib/tau/wearable/theme/default/tau.circle.css">
-	<link rel="stylesheet" href="../../../css/style.css">
+		  href="../../lib/tau/wearable/theme/default/tau.circle.css">
+	<link rel="stylesheet" href="../../css/style.css">
 	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
-		  href="../../../css/style.circle.css">
+		  href="../../css/style.circle.css">
+	<script src="../../lib/tau/wearable/js/tau.js">
+	</script>
 </head>
 <body>
 	<div class="ui-page" id="dimmer-page">

--- a/examples/wearable/UIComponents/contents/graphs/bar_graph.html
+++ b/examples/wearable/UIComponents/contents/graphs/bar_graph.html
@@ -1,8 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.css">
-	<link rel="stylesheet" href="../../css/style.css">
+	<meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport" />
+	<link href="../../lib/tau/wearable/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../lib/tau/wearable/theme/default/tau.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
+	<link href="../../css/style.css" rel="stylesheet" />
+	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
+	<script src="../../js/circle-helper.js">
+	</script>
+	<script src="../../lib/tau/wearable/js/tau.js">
+	</script>
 </head>
 <body>
 <div class="ui-page" id="bar-graph-page">

--- a/examples/wearable/UIComponents/contents/graphs/dynamic_graph.html
+++ b/examples/wearable/UIComponents/contents/graphs/dynamic_graph.html
@@ -1,8 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.css">
-	<link rel="stylesheet" href="../../css/style.css">
+	<meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport" />
+	<link href="../../lib/tau/wearable/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../lib/tau/wearable/theme/default/tau.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
+	<link href="../../css/style.css" rel="stylesheet" />
+	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
+	<script src="../../js/circle-helper.js">
+	</script>
+	<script src="../../lib/tau/wearable/js/tau.js">
+	</script>
 </head>
 <body>
 <div class="ui-page" id="dynamic-graph-page">

--- a/examples/wearable/UIComponents/contents/graphs/index.html
+++ b/examples/wearable/UIComponents/contents/graphs/index.html
@@ -1,8 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.min.css">
-	<link rel="stylesheet" href="../../css/style.css">
+	<meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport" />
+	<link href="../../lib/tau/wearable/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../lib/tau/wearable/theme/default/tau.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
+	<link href="../../css/style.css" rel="stylesheet" />
+	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
+	<script src="../../js/circle-helper.js">
+	</script>
+	<script src="../../lib/tau/wearable/js/tau.js">
+	</script>
 </head>
 <body>
 <div class="ui-page">
@@ -17,6 +24,5 @@
 		</ul>
 	</div>
 </div>
-<script type="text/javascript" src="../../lib/tau/mobile/js/tau.min.js" data-build-remove="false"></script>
 </body>
 </html>

--- a/examples/wearable/UIComponents/contents/graphs/static_graph.html
+++ b/examples/wearable/UIComponents/contents/graphs/static_graph.html
@@ -1,8 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link rel="stylesheet" href="../../lib/tau/mobile/theme/default/tau.css">
-	<link rel="stylesheet" href="../../css/style.css">
+	<meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport" />
+	<link href="../../lib/tau/wearable/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../lib/tau/wearable/theme/default/tau.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
+	<link href="../../css/style.css" rel="stylesheet" />
+	<link href="../../css/style.circle.css" media="all and (-tizen-geometric-shape: circle)" rel="stylesheet" />
+	<script src="../../js/circle-helper.js">
+	</script>
+	<script src="../../lib/tau/wearable/js/tau.js">
+	</script>
 </head>
 <body>
 <div class="ui-page" id="static-graph-page">


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/440
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/439
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/436
[Problem] Widgets not visible
[Solution] Fix header section with proper links to TAU
[Test]
Exemplary test links for WATT
http://localhost:3000/demos?path=1.1%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Fgraphs%2Fstatic_graph.html
http://localhost:3000/demos?path=1.1%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fgraphs%2Fstatic_graph.html
http://localhost:3000/demos?path=1.1%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Fcontrols%2Fdimmer.html

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>