### PR TITLE
Add href resources so wget can download them

### DIFF
--- a/examples/mobile/UIComponents/components/interactive/interactive3D/index.html
+++ b/examples/mobile/UIComponents/components/interactive/interactive3D/index.html
@@ -4,6 +4,10 @@
 	<link rel="stylesheet" href="../../../lib/tau/mobile/theme/default/tau.css">
 	<link rel="stylesheet" href="../../../css/style.css">
 	<script type="text/javascript" src="../../../lib/tau/mobile/js/tau.js" data-build-remove="false"></script>
+	<!-- below hrefs are for wget so it can download external resources-->
+	<link href="assets/Duck.gltf">
+	<link href="assets/DuckCM.png">
+	<link href="assets/Duck0.bin">
 </head>
 <body>
 <div data-role="page" class="ui-page" id="demo-i3d-page">

--- a/examples/wearable/UIComponents/contents/interactive/interactive3D/index.html
+++ b/examples/wearable/UIComponents/contents/interactive/interactive3D/index.html
@@ -9,6 +9,10 @@
 	<link rel="stylesheet" href="../../../css/style.css">
 	<link rel="stylesheet" media="all and (-tizen-geometric-shape: circle)"
 		href="../../../css/style.circle.css">
+	<!-- below hrefs are for wget so it can download external resources-->
+	<link href="assets/Duck.gltf">
+	<link href="assets/DuckCM.png">
+	<link href="assets/Duck0.bin">
 </head>
 <body>
 <div class="ui-page">


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/437
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/441
[Problem] Interactive 3D widget not working on code.tizen.org
due to the missing resources
[Solution] Add href attributes so wget can download external resources
[Test]
1. Run WATT
2. Visit links:
http://localhost:3000/demos?path=1.1%2Fexamples%2Fmobile%2FUIComponents%2Fcomponents%2Finteractive%2Finteractive3D%2Findex.html
https://localhost:3000/demos?path=1.1%2Fexamples%2Fwearable%2FUIComponents%2Fcontents%2Finteractive%2Fcoverflow%2Findex.html
3. Make sure that duck is displayed after running live preview.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>