### PR TITLE
Remove padding-bottom for Coverflow example

### DIFF
--- a/examples/wearable/UIComponents/contents/interactive/coverflow/index.html
+++ b/examples/wearable/UIComponents/contents/interactive/coverflow/index.html
@@ -12,7 +12,7 @@
 	<div class="ui-header" data-position="fixed">
 		<h1>CoverFlow</h1>
 	</div>
-	<div class="ui-content">
+	<div class="ui-content" style="padding-bottom: 0">
 		<div class="ui-coverflow" data-effect="carousel">
 			<ul class="flip-items">
 				<li><img src="images/1.jpg" width="150px" height="150px"></li>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/442
[Problem] Can scroll up content of coverflow example
[Solution] Set pading-bottom CSS property to 0 for ui-content.
This property is inherited from
tau.circle.css:448
.ui-page.ui-scroll-on .ui-content {
  margin-top: 7.1875rem;
  padding-bottom: 6.25rem;
  padding-top: 0;
}
It is in order to allow scrolling app content up, because some items are not visible.
In case of coverflow app this approach is not needed because widget fills in screen.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>