### PR TITLE
Set getDividers to proper values

### DIFF
--- a/examples/wearable/UIComponents/contents/navcontrols/indexscrollbar/indexScrollbar.js
+++ b/examples/wearable/UIComponents/contents/navcontrols/indexscrollbar/indexScrollbar.js
@@ -13,7 +13,7 @@
 	 */
 	page.addEventListener("pageshow", function () {
 		var indexScrollbarElement = document.getElementById("indexscrollbar"),
-			listDividers = listviewElement.getElementsByClassName("ui-listview-divider"),	// list dividers
+			listDividers = tau.engine.getBinding(listviewElement).getDividers(),	// list dividers
 			dividers = {},	// collection of list dividers
 			indices = [],	// index list
 			divider,

--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -1456,6 +1456,17 @@
 				});
 			}
 
+			/**
+			 * Return all dividers (category names in items' list)
+			 * @method getDividers
+			 * @memberof ns.widget.wearable.ArcListview
+			 */
+			prototype.getDividers = function () {
+				return this._items
+					.filter(function (elem) {
+						return elem.classList.contains(classes.DIVIDER);
+					});
+			}
 
 			/**
 			 * Widget init method


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/131
[Problem] Circular Index Scrollbar indexes not displayed
[Solution] Set getDividers to proper values

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>