### PR TITLE
Fix missing images issue for code.tizen.org

### DIFF
--- a/examples/mobile/UIComponents/components/gallery/gallery.html
+++ b/examples/mobile/UIComponents/components/gallery/gallery.html
@@ -5,6 +5,10 @@
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
 	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
+	<link href="images/add0.jpg" />
+	<link href="images/add1.jpg" />
+	<link href="images/add2.jpg" />
+	<link href="images/add3.jpg" />
 	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
 	</script>
 </head>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU-Design-Editor/issues/445
[Problem] No images when using code.tizen.org examles
[Solution] Add link href references so wget can download them

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>