### PR TITLE
Bottom button highlights out of area when clicked

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/layout.less
+++ b/src/css/profile/wearable/changeable/theme-circle/layout.less
@@ -222,6 +222,7 @@ body {
 				.transition(opacity 200ms);
 				opacity: 0;
 				z-index: -1;
+				border-radius: 60 * @unit_base;
 			}
 
 			&.ui-btn-active {


### PR DESCRIPTION
- Applies only the button area with the border-radius value.