### PR TITLE
SnapListview: fix for detect scrollend

### DIFF
--- a/src/js/profile/wearable/widget/wearable/SnapListview.js
+++ b/src/js/profile/wearable/widget/wearable/SnapListview.js
@@ -205,7 +205,7 @@
 				},
 
 				// time threshold for detect scroll end
-				SCROLL_END_TIME_THRESHOLD = 0;
+				SCROLL_END_TIME_THRESHOLD = 150;
 
 			SnapListview.classes = classes;
 			SnapListview.animationTimer = null;


### PR DESCRIPTION
[Issue] N/A
[Problem] SnapListview is triggering "scrollend" and "scrollstart" on each
 "scroll" event
[Solution] Detection of scroll end is realized by set timeout on scroll.
 When scoll event is not triggering during indicated period then
 scroll end event is triggering. The timeout was set on "zero" this
 cause issue. Now, this value is changing now to 150ms.

I verified possible regression. I didn't reproduce issue.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>