### PR TITLE
Fix problem that scrollToPosition is not working correctly

### DIFF
--- a/src/js/core/util/scrolling.js
+++ b/src/js/core/util/scrolling.js
@@ -46,6 +46,7 @@
 				// current state of scroll position
 				scrollPosition = 0,
 				lastScrollPosition = 0,
+				baseScrollPosition = 0,
 				moveToPosition = 0,
 				lastRenderedPosition = 0,
 				lastTime = Date.now(),
@@ -536,7 +537,7 @@
 			 */
 			function render() {
 				// calculate ne position of scrolling as sum of last scrolling state + move
-				var newRenderedPosition = scrollPosition + lastScrollPosition;
+				var newRenderedPosition = scrollPosition + lastScrollPosition + baseScrollPosition;
 				// is position was changed
 
 				if (newRenderedPosition !== lastRenderedPosition) {
@@ -806,17 +807,16 @@
 				return maxScrollPosition;
 			}
 
-			function scrollToIndex(index) {
-				var previousIndex = currentIndex;
-
+			function scrollToIndex(index, from) {
 				currentIndex = index;
 
-				if (snapPoints) {
-					moveToPosition = snapPoints[index].position;
-					snapSize = Math.abs(snapPoints[previousIndex].position - snapPoints[index].position);
-				} else {
-					moveToPosition = snapSize * index;
-				}
+				// Set the scroll position by index
+				baseScrollPosition = from;
+				scrollPosition = -getScrollPositionByIndex(index);
+				moveToPosition = scrollPosition;
+
+				// Enforce redraw to apply selected effect
+				render();
 			}
 
 			/**

--- a/src/js/profile/wearable/widget/wearable/SnapListview.js
+++ b/src/js/profile/wearable/widget/wearable/SnapListview.js
@@ -784,23 +784,25 @@
 			 * Scroll SnapList by index
 			 * @method scrollToPosition
 			 * @param {number} index
+			 * @param {boolean} skipAnimation
 			 * @public
 			 * @return {boolean} True if the list was scrolled, false - otherwise.
 			 * @member ns.widget.wearable.SnapListview
 			 */
-			prototype.scrollToPosition = function (index) {
-				return this._scrollToPosition(index);
+			prototype.scrollToPosition = function (index, skipAnimation) {
+				return this._scrollToPosition(index, skipAnimation);
 			};
 
 			/**
 			 * Scroll SnapList by index
 			 * @method _scrollToPosition
 			 * @param {number} index
+			 * @param {boolean} skipAnimation
 			 * @param {Function} callback
 			 * @protected
 			 * @member ns.widget.wearable.SnapListview
 			 */
-			prototype._scrollToPosition = function (index, callback) {
+			prototype._scrollToPosition = function (index, skipAnimation, callback) {
 				var self = this,
 					ui = self._ui,
 					enabled = self._enabled,
@@ -825,7 +827,14 @@
 				listItemIndex = listItems[index].coord;
 				dest = listItemIndex.top - scrollableParent.height / 2 + listItemIndex.height / 2;
 
-				scrollAnimation(scrollableParent.element, -scrollableParent.element.firstElementChild.getBoundingClientRect().top, dest, 450, callback);
+				if (skipAnimation) {
+					scrollableParent.element.scrollTop = dest;
+				} else {
+					scrollAnimation(scrollableParent.element, -scrollableParent.element.firstElementChild.getBoundingClientRect().top, dest, 450, callback);
+				}
+
+				// sync scroll position and index with scroller
+				scrolling.scrollToIndex(index, dest);
 
 				return true;
 			};
@@ -850,7 +859,6 @@
 					progress = 0,
 					easeProgress = 0,
 					distance = to - from,
-					scrollTop = element.scrollTop,
 					animationTimer = SnapListview.animationTimer;
 
 				startTime = window.performance.now();
@@ -864,7 +872,7 @@
 					progress = (currentTime - startTime) / duration;
 					easeProgress = easeOut(progress);
 					gap = distance * easeProgress;
-					element.scrollTop = scrollTop + gap;
+					element.scrollTop = from + gap;
 					if (progress <= 1 && progress >= 0) {
 						animationTimer = window.requestAnimationFrame(animation);
 					} else {


### PR DESCRIPTION
[Issue] N/A
[Problem] SnapListview.scrollToPosition is not working
[Solution] Sync the index and position with scroller
and calculate the rendered position with the scrolled
value and add the 'skipAnimation' to skip the animation

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>