### PR TITLE
fixup: Fix problem that scrollToPosition is not working correctly

### DIFF
--- a/src/js/core/util/scrolling.js
+++ b/src/js/core/util/scrolling.js
@@ -571,6 +571,7 @@
 				lastScrollPosition = 0;
 				moveToPosition = 0;
 				lastRenderedPosition = 0;
+				baseScrollPosition = 0;
 				lastTime = Date.now();
 			}
 

--- a/src/js/profile/wearable/widget/wearable/SnapListview.js
+++ b/src/js/profile/wearable/widget/wearable/SnapListview.js
@@ -163,6 +163,7 @@
 					self._currentIndex = null;
 					self._enabled = true;
 					self._isTouched = false;
+					self._isScrollToPosition = false;
 					self._scrollEventCount = 0;
 					self._marginTop = 0;
 				},
@@ -667,7 +668,7 @@
 				self._unbindEvents();
 
 				scroller = getScrollableParent(self.element);
-				if (scroller) {
+				if (scroller && !self._isScrollToPosition) {
 					scroller.scrollTop = 0;
 				}
 
@@ -675,6 +676,7 @@
 				self._callbacks = null;
 				self._listItems = null;
 				self._isScrollStarted = null;
+				self._isScrollToPosition = null;
 
 				if (self._scrollEndTimeoutId) {
 					window.clearTimeout(self._scrollEndTimeoutId);
@@ -821,6 +823,7 @@
 				}
 
 				self._currentIndex = index;
+				self._isScrollToPosition = true;
 
 				removeSelectedClass(self);
 


### PR DESCRIPTION
[Problem] Scroll is not working correctly when using the scrollToIndex
[Solution] Restore the default position of scroller when destroying the
snaplistview

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>