### PR TITLE
Unbind the events on TimePicker correctly

### DIFF
--- a/src/js/profile/wearable/widget/wearable/TimePicker.js
+++ b/src/js/profile/wearable/widget/wearable/TimePicker.js
@@ -789,8 +789,8 @@
 
 				utilsEvents.off(document, "rotarydetent", self, true);
 				utilsEvents.off(document, "click", self, true);
-				utilsEvents.on(ui.numberMinutes, "spinchange", self, true);
-				utilsEvents.on(ui.numberHours, "spinchange", self, true);
+				utilsEvents.off(ui.numberMinutes, "spinchange", self, true);
+				utilsEvents.off(ui.numberHours, "spinchange", self, true);
 			};
 
 			TimePicker.prototype = prototype;


### PR DESCRIPTION
[Issue] N/A
[Problem] "spinchange" events are not turned off when unbinding the events
[Solution] Turn off "spinchange" events when unbinding the events

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>