### PR TITLE
Turn off the wrong event when unbinding the events

### DIFF
--- a/src/js/profile/wearable/widget/wearable/Spin.js
+++ b/src/js/profile/wearable/widget/wearable/Spin.js
@@ -597,7 +597,7 @@
 			prototype._unbindEvents = function () {
 				var self = this;
 
-				utilsEvents.off(self.element, "drag dragend", self);
+				utilsEvents.off(document, "drag dragend", self);
 				utilsEvents.off(self.element, "click", self);
 			};
 


### PR DESCRIPTION
[Issue] N/A
[Problem] Turn off the "drag dragend" events to the wrong target
[Solution] Change the target to the document

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>