### PR TITLE
Spin: Event "spinchange" has stopped when widget is in disabled state

### DIFF
--- a/src/js/profile/wearable/widget/wearable/Spin.js
+++ b/src/js/profile/wearable/widget/wearable/Spin.js
@@ -513,6 +513,8 @@
 					}, ENABLING_DURATION);
 					element.classList.remove(classes.ENABLED);
 					utilsEvents.off(document, "drag dragend", self);
+					// disable animation
+					self._animation.stop();
 				}
 				// reset previous value;
 				this._prevValue = null;


### PR DESCRIPTION
[Issue] N/A
[Problem] SPIN is moving automatically even though it was not up/down
[Solution] Spin event is triggering by animation, this cause issue when widget
 is disabled during animation.
 Stopping the animation on widget disabling is solution for the issue

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>