### PR TITLE
Page, ArcListview: Changing scroll position of hidden page

### DIFF
--- a/src/js/core/widget/core/Page.js
+++ b/src/js/core/widget/core/Page.js
@@ -970,6 +970,17 @@
 				return scroller || element.querySelector("." + classes.uiContent) || element;
 			};
 
+			/**
+			 * This method sets scroll position when page is hidden.
+			 * New page scroll position will be restored on "pagebeforeshow"
+			 * @param {number} scrollPosition last scroll position to set
+			 * @method setLastScrollPosition
+			 * @member ns.widget.core.Page
+			 */
+			prototype.setLastScrollPosition = function (scrollPosition) {
+				this._lastScrollPosition = scrollPosition;
+			}
+
 			Page.prototype = prototype;
 
 			Page.createEmptyElement = function () {

--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -487,7 +487,8 @@
 					currentTime = Date.now(),
 					startTime = state.startTime,
 					deltaTime = currentTime - startTime,
-					scroll = state.scroll;
+					scroll = state.scroll,
+					pageWidget = null;
 
 				if (deltaTime >= state.duration) {
 					self._scrollAnimationEnd = true;
@@ -510,6 +511,10 @@
 						});
 						eventUtils.trigger(state.items[state.currentIndex].element, "selected");
 						state.toIndex = state.currentIndex;
+
+						// set last scroll position when current page is hidden
+						pageWidget = ns.engine.getBinding(self._ui.page, "Page");
+						pageWidget.setLastScrollPosition(-1 * scroll.current || 0);
 
 						scroll.to = null;
 						scroll.from = null;


### PR DESCRIPTION
[Issue] N/A
[Problem] List text is overlap with Title
Reproduction path:
1. Select 'List'
2. Touch on 'Button List' without select before
3. Back button

[Solution] Added possibility to set the last scroll position of hidden page.
 When animation of list scroll is ending then scroll position is set for
 hidden page.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>