### PR TITLE
Enable rotary scrolling for circle wearable devices

### DIFF
--- a/examples/wearable/UIComponents/js/circle-helper.js
+++ b/examples/wearable/UIComponents/js/circle-helper.js
@@ -17,12 +17,15 @@ document.addEventListener("tauinit", function () {
 				pageId = page.id,
 				list;
 
+			tau.util.rotaryScrolling.enable(event.target.firstElementChild);
+
 			if (!page.classList.contains("page-snaplistview") &&
 				pageId !== "page-snaplistview" &&
 				pageId !== "page-swipelist" &&
 				pageId !== "page-marquee-list" &&
 				pageId !== "page-multiline-list") {
 				list = page.querySelector(".ui-listview");
+
 				if (list) {
 					tau.widget.Listview(list);
 				}


### PR DESCRIPTION
[Problem] Rotary scrolling didn't work in circle wearable devices.
[Solution] Enable rotary scrolling in circle-helper

Signed-off-by: Hubert Siwkin <h.siwkin@samsung.com>