### PR TITLE
Fix the problem that cannot build widget with one or none items

### DIFF
--- a/src/js/profile/wearable/widget/wearable/SnapListview.js
+++ b/src/js/profile/wearable/widget/wearable/SnapListview.js
@@ -448,13 +448,25 @@
 				// finding page  and scroller
 				ui.page = utilSelector.getClosestByClass(listview, "ui-page") || document.body;
 
-				scroller = getScrollableParent(listview);
+				scroller = getScrollableParent(listview) ||
+					ui.page.querySelector(".ui-scroller") ||
+					ui.page;
 				if (scroller) {
+					scroller.classList.add(classes.SNAP_CONTAINER);
+					ui.scrollableParent.element = scroller;
+
+					visibleOffset = scroller.clientHeight;
+					ui.scrollableParent.height = visibleOffset;
+
+					listItem = listview.querySelector(self.options.selector);
+					if (!listItem) {
+						return scroller;
+					}
+
 					if (!scrolling.isElement(scroller)) {
 						scrolling.enable(scroller, "y");
 					}
 
-					listItem = listview.querySelector(self.options.selector);
 					elementHeight = (listItem) ? listItem.getBoundingClientRect().height : 0;
 
 					scrollMargin = listview.getBoundingClientRect().top -
@@ -468,12 +480,6 @@
 							length: item.coord.height
 						};
 					}));
-
-					scroller.classList.add(classes.SNAP_CONTAINER);
-					ui.scrollableParent.element = scroller;
-
-					visibleOffset = scroller.clientHeight;
-					ui.scrollableParent.height = visibleOffset;
 				}
 				return scroller;
 			};
@@ -509,6 +515,11 @@
 						self._currentIndex = index;
 					}
 				});
+
+				if (listItems.length == 0) {
+					return;
+				}
+
 				scrolling.setSnapSize(listItems.map(function (item) {
 					return {
 						position: item.coord.top,


### PR DESCRIPTION
[Issue] #477
[Problem] Scroller is not assigned when the item is one or none
[Solution] Assign the body element when there is no scrollable parent

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>