### PR TITLE
SnapListview: Fix to get a correct index from the widget

### DIFF
--- a/src/js/profile/wearable/widget/wearable/SnapListview.js
+++ b/src/js/profile/wearable/widget/wearable/SnapListview.js
@@ -729,7 +729,7 @@
 			 * @member ns.widget.wearable.SnapListview
 			 */
 			prototype.getSelectedIndex = function () {
-				return this._currentIndex || this._selectedIndex;
+				return this._selectedIndex;
 			};
 
 			function vClickHandler(self, e) {


### PR DESCRIPTION
[Issue] N/A
[Problem] getSelectedIndex get an wrong index after come back from
another page
[Solution] Return the selected index

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>