### PR TITLE
Revert "Enable rotary scrolling for circle wearable devices"

### DIFF
--- a/examples/wearable/UIComponents/js/circle-helper.js
+++ b/examples/wearable/UIComponents/js/circle-helper.js
@@ -17,15 +17,12 @@ document.addEventListener("tauinit", function () {
 				pageId = page.id,
 				list;
 
-			tau.util.rotaryScrolling.enable(event.target.firstElementChild);
-
 			if (!page.classList.contains("page-snaplistview") &&
 				pageId !== "page-snaplistview" &&
 				pageId !== "page-swipelist" &&
 				pageId !== "page-marquee-list" &&
 				pageId !== "page-multiline-list") {
 				list = page.querySelector(".ui-listview");
-
 				if (list) {
 					tau.widget.Listview(list);
 				}


### PR DESCRIPTION
Reverts Samsung/TAU#539

As per comment:

"This patch adding redundant support for rotation for content & lists. The lists have own support for rotary event. This PR may cause issues hard to predict."