### PR TITLE
Marquee: fix infinite animation

### DIFF
--- a/src/js/core/widget/core/Marquee.js
+++ b/src/js/core/widget/core/Marquee.js
@@ -195,7 +195,7 @@
 				defaults = {
 					marqueeStyle: style.SLIDE,
 					speed: 60,
-					iteration: 1,
+					iteration: "1",
 					currentIteration: 1,
 					delay: 0,
 					timingFunction: "linear",

--- a/tests/js/core/widget/core/Marquee/api/marquee.js
+++ b/tests/js/core/widget/core/Marquee/api/marquee.js
@@ -1,11 +1,15 @@
+/* global equal, test */
 (function (ns) {
-    "use strict";
-    module("core/widget/core/Marquee/api/marquee");test ( "API of core Marquee Widget" , function () {
-        var widget, Marquee;
-        equal(typeof ns, "object", "Class ns exists");
-        equal(typeof ns.widget, "object", "Class ns.widget exists");
-        equal(typeof ns.widget.core, "object", "Class ns.widget.core exists");
-        equal(typeof ns.widget.core.Marquee, "function", "Class ns.widget.mobile.Marquee exists");
+	"use strict";
+	module("core/widget/core/Marquee/api/marquee");
+	test("API of core Marquee Widget", function () {
+		var widget,
+			Marquee;
+
+		equal(typeof ns, "object", "Class ns exists");
+		equal(typeof ns.widget, "object", "Class ns.widget exists");
+		equal(typeof ns.widget.core, "object", "Class ns.widget.core exists");
+		equal(typeof ns.widget.core.Marquee, "function", "Class ns.widget.mobile.Marquee exists");
 
 		widget = ns.engine.instanceWidget(document.getElementById("marquee"), "Marquee");
 		Marquee = ns.widget.core.Marquee;

--- a/tests/js/core/widget/core/Marquee/api/marquee.js
+++ b/tests/js/core/widget/core/Marquee/api/marquee.js
@@ -23,7 +23,7 @@
 		equal(typeof widget.options, "object", "Property marquee.options exists");
 		equal(typeof widget.options.marqueeStyle, "string", "Property marquee.options.marqueeStyle exists");
 		equal(typeof widget.options.speed, "number", "Property marquee.options.speed exists");
-		equal(typeof widget.options.iteration, "number", "Property marquee.options.iteration exists");
+		equal(typeof widget.options.iteration, "string", "Property marquee.options.iteration exists");
 		equal(typeof widget.options.delay, "number", "Property marquee.options.delay exists");
 		equal(typeof widget.options.timingFunction, "string", "Property marquee.options.timingFunction exists");
 		equal(typeof widget.options.runOnlyOnEllipsisText, "boolean", "Property marquee.options.runOnlyEllipsisText exists");


### PR DESCRIPTION
[Issue] N/A
[Problem] Infinite animation is running only for one iteration.
[Solution] Change "iteration" type to "string". When using string both
number and "infinite" are parsed correctly.

Signed-off-by: Grzegorz Wolny <g.wolny@samsung.com>