### PR TITLE
Don't set selected month in DatePicker

### DIFF
--- a/src/js/profile/wearable/widget/wearable/DatePicker.js
+++ b/src/js/profile/wearable/widget/wearable/DatePicker.js
@@ -133,14 +133,13 @@
 			}
 
 			/**
-			 * Initialize widget state, set current date and init month indicator
+			 * Initialize widget state, set current date
 			 * @method _init
 			 * @memberof ns.widget.wearable.DatePicker
 			 * @protected
 			 */
 			prototype._init = function () {
 				this._setValue(new Date());
-				this._setActiveSelector("month");
 			};
 
 			/**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/546
[Problem] In UI Components app DatePicker example has month selected.
Other Examples like DateTime Picker have no default value selected.
[Solution] Modify DatePicker to not set default selection.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>