### PR TITLE
Fix hiding header while scrolling on short lists

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/arclistview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/arclistview.less
@@ -4,7 +4,7 @@
 	overflow: hidden;
 	top: 0;
 	left: 0;
-
+	min-height: 250 * @unit_base;
 	&-carousel {
 		position: absolute;
 		top: 0;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/548
[Problem] Header isn't totally hidden while list is scrolling and there
is too few elements on the one.
[Solution] Enforce minimal list height

Signed-off-by: Kornelia Kobiela <k.kobiela@samsung.com>