### PR TITLE
fixup! fixup! fixup! Fix problem that scrollToPosition is not working correctly

### DIFF
--- a/src/js/profile/wearable/widget/wearable/SnapListview.js
+++ b/src/js/profile/wearable/widget/wearable/SnapListview.js
@@ -343,14 +343,11 @@
 			prototype._listItemAnimate = function (scrollValue) {
 				var self = this,
 					anim = self.options.animate,
-					animateCallback = self._callbacks[anim],
-					scrollPosition;
+					animateCallback = self._callbacks[anim];
 
 				if (animateCallback) {
-					scrollPosition = scrollValue || scrolling.getScrollPosition();
-
 					utilArray.forEach(self._listItems, function (item) {
-						item.animate(scrollPosition, animateCallback);
+						item.animate(scrollValue, animateCallback);
 					});
 				}
 			};
@@ -379,7 +376,9 @@
 					removeSelectedClass(self);
 				}
 
-				self._listItemAnimate(event && event.detail && event.detail.scrollTop);
+				if (event && event.detail) {
+					self._listItemAnimate(event.detail.scrollTop);
+				}
 
 				// scrollend handler can be run only when all touches are released.
 				if (self._isTouched === false) {
@@ -505,7 +504,7 @@
 				}));
 
 				self._listItems = listItems;
-				self._listItemAnimate();
+				self._listItemAnimate(scrolling.getScrollPosition());
 			};
 
 			/**

--- a/tests/js/profile/wearable/widget/wearable/SnapListview/SnapListview.js
+++ b/tests/js/profile/wearable/widget/wearable/SnapListview/SnapListview.js
@@ -177,12 +177,12 @@
 				assert.ok(true, "method: ns.utill.array was called");
 			});
 
-			snaplistWidget._listItemAnimate();
+			snaplistWidget._listItemAnimate(0 /* scroll position */);
 
 			helpers.restoreStub(ns.util.array, "forEach");
 		});
 
-		QUnit.test("scrollHandler", 3, function (assert) {
+		QUnit.test("scrollHandler", 4, function (assert) {
 			var snaplistWidget = new SnapListview({animate: "scale"}),
 				element = document.getElementById("snap-list");
 
@@ -192,12 +192,17 @@
 			snaplistWidget._isScrollStarted = true;
 			snaplistWidget._isTouched = true;
 
-			helpers.stub(snaplistWidget, "_listItemAnimate", function () {
+			helpers.stub(snaplistWidget, "_listItemAnimate", function (scrollPos) {
 				assert.ok(true, "method: _listItemAnimate was called");
+				assert.ok(scrollPos !== undefined, "method: _listItemAnimate has parameter");
 			});
 
 			assert.equal(snaplistWidget._scrollEventCount, 0, "not event one scrollHandler was generated");
-			snaplistWidget._callbacks.scroll(snaplistWidget);
+			snaplistWidget._callbacks.scroll(new CustomEvent("scroll", {
+				detail: {
+					scrollTop: 0
+				}
+			}));
 			assert.equal(snaplistWidget._scrollEventCount, 1, "scrollHandler was generated");
 
 			helpers.restoreStub(snaplistWidget, "_listItemAnimate");


### PR DESCRIPTION
Issue: N/A

Problem: In SnapListView, while scrolling an item gets bigger

Cause: while scrolling, _listItemAnimate(scrollValue) function is called
	where current scoll position is passed as param. When '0' (no scroll)
	is passed, the following function is called:

		 scrolling.getScrollPosition()

	which returns outdated scroll position (before scroll) during scroll (when
	scroll finishes and 'touchend' comes, scroll position is fine).

Solution:
	Accept '0' as correct position of scroll passed to _listItemAnimate() func.
	Pass scrolling.getScrollPosition() to _listItemAnimate on refresh func to
	restore scroll position.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>