### PR TITLE
Marquee: fix setIteration

### DIFF
--- a/src/js/core/widget/core/Marquee.js
+++ b/src/js/core/widget/core/Marquee.js
@@ -448,7 +448,7 @@
 				var animation = self._animation,
 					state = self.state;
 
-				if (self.options.currentIteration++ < self.options.iteration) {
+				if (self.options.currentIteration++ < self.options.iteration || self.options.iteration === "infinite") {
 					animation.set(state.animation, state.animationConfig);
 					animation.stop();
 					animation.start();
@@ -480,7 +480,7 @@
 					animationConfig.callback = animationIterationCallback.bind(null, self);
 				}
 				self._animation.set(state.animation, animationConfig);
-				self.options.loop = value;
+				self.options.iteration = value;
 				return false;
 			};
 

--- a/tests/js/core/widget/core/Marquee/Marquee.js
+++ b/tests/js/core/widget/core/Marquee/Marquee.js
@@ -281,7 +281,7 @@
 		});
 
 
-		test("_setIteration", 18, function (assert) {
+		test("_setIteration", 28, function (assert) {
 			var marquee = new Marquee(),
 				marqueeElement = document.getElementById("marquee"),
 				animationObject = {
@@ -295,6 +295,9 @@
 				},
 				start: function () {
 					assert.ok(true, "animation start was called");
+				},
+				stop: function () {
+					assert.ok(true, "animation stop was called");
 				},
 				reset: function () {
 					assert.ok(true, "animation reset was called");
@@ -319,7 +322,7 @@
 			assert.equal(
 				marquee._setIteration(null, "2"),
 				false,
-				"null, '2'");
+				"null, 2");
 			assert.equal(typeof configObject.callback, "function", "callback is set");
 			configObject.callback();
 			configObject.callback();
@@ -327,6 +330,12 @@
 				marquee._setIteration(null, 3),
 				false,
 				"null, 3");
+			assert.equal(typeof configObject.callback, "function", "callback is set");
+			configObject.callback();
+			assert.equal(
+				marquee._setIteration(null, "foo"),
+				false,
+				"null, NaN");
 			assert.equal(typeof configObject.callback, "function", "callback is set");
 			configObject.callback();
 		});

--- a/tests/js/core/widget/core/Marquee/api/marquee.js
+++ b/tests/js/core/widget/core/Marquee/api/marquee.js
@@ -27,7 +27,7 @@
 		equal(typeof widget.options, "object", "Property marquee.options exists");
 		equal(typeof widget.options.marqueeStyle, "string", "Property marquee.options.marqueeStyle exists");
 		equal(typeof widget.options.speed, "number", "Property marquee.options.speed exists");
-		equal(typeof widget.options.iteration, "string", "Property marquee.options.iteration exists");
+		equal(typeof widget.options.iteration, "number", "Property marquee.options.iteration exists");
 		equal(typeof widget.options.delay, "number", "Property marquee.options.delay exists");
 		equal(typeof widget.options.timingFunction, "string", "Property marquee.options.timingFunction exists");
 		equal(typeof widget.options.runOnlyOnEllipsisText, "boolean", "Property marquee.options.runOnlyEllipsisText exists");


### PR DESCRIPTION
[Issue] N/A
[Problem] Changing iteration by javascript does not work
[Solution] Save new value of iteration in correct variable. Correct
conditions in animation callback to make possible a change from counted
animation to the infinite one.

Now following scenario works:
var m = tau.engine.getBinding(document.getElementById("marquee1"));
m.option("iteration", 5);
m.option("iteration", "infinite");

Signed-off-by: Grzegorz Wolny <g.wolny@samsung.com>