### PR TITLE
Arclistview: ensure correct radio button selected after scroll

### DIFF
--- a/src/css/profile/wearable/changeable/theme-circle/arclistview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/arclistview.less
@@ -128,6 +128,10 @@
 	position: relative !important;
 }
 
+.ui-arc-listview-dummy-element {
+	display: none;
+}
+
 /* Keyboard is visible, screen height is lower then half of screen */
 @media (max-height: 180px) {
 	.ui-arc-listview-carousel li {

--- a/tests/js/profile/wearable/widget/wearable/ArcListview/ArcListview.js
+++ b/tests/js/profile/wearable/widget/wearable/ArcListview/ArcListview.js
@@ -31,7 +31,10 @@
 
 			assert.deepEqual(arclistWidget._ui, {
 				scroller: null,
-				selection: null
+				selection: null,
+				arcListviewCarousel: null,
+				arcListviewSelection: null,
+				dummyElement: null
 			}, "_ui was correct initialized");
 
 			assert.deepEqual(arclistWidget.options, {
@@ -230,8 +233,8 @@
 		QUnit.test("_drawItem", function (assert) {
 			var listWidget = new ArcListview(),
 				element = document.getElementById("arc-list"),
-				removeChild = function () {
-					assert.ok("remove child was called");
+				appendChild = function () {
+					assert.ok("append child was called");
 				},
 				querySelector = function () {
 					assert.ok("find text content");
@@ -239,9 +242,6 @@
 				item = {
 					element: {
 						style: {},
-						parentNode: {
-							removeChild: removeChild
-						},
 						querySelector: querySelector
 					},
 					current: {
@@ -253,12 +253,13 @@
 			expect(5);
 			listWidget.element = element;
 			listWidget._state.currentIndex = 2;
+			listWidget._ui.dummyElement = {
+				appendChild: appendChild
+			};
 			listWidget._carousel = {
 				items: [{
 					carouselElement: {
-						appendChild: function () {
-							assert.ok("append child was called");
-						}
+						appendChild: appendChild
 					},
 					carouselSeparator: {
 						style: {},
@@ -278,9 +279,6 @@
 							"opacity": 1.15,
 							"transform": "translateY(-50%) scale3d(1,1,1)"
 						},
-						"parentNode": {
-							"removeChild": removeChild
-						},
 						"querySelector": querySelector
 					},
 					"repaint": false
@@ -296,9 +294,6 @@
 						"scale": 0
 					},
 					"element": {
-						"parentNode": {
-							"removeChild": removeChild
-						},
 						"style": {
 							"opacity": 1.15,
 							"transform": "translateY(-50%) scale3d(1,1,1)"


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU/issues/458

Problem: old item remains selected and new item loses selection after scrolling

Cause: If selected element goes out of screen, it's removed form DOM tree.
	Let's assume that new element is selected. Then we come back to previous scroll position.
	The removed element is added to tree again. Since it was in selected state,
	latest selected element losses selection and selection is added to old radio button.

Solution: add dummy element to Arclistview widget. Add to it elements that are removed from
	carousel.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>