### PR TITLE
(util) rotaryScrolling: added new methods for lock/unclock of scrolling

### DIFF
--- a/examples/wearable/UIComponents/contents/controls/marquee/index.html
+++ b/examples/wearable/UIComponents/contents/controls/marquee/index.html
@@ -17,7 +17,7 @@
 	</head>
 
 <body>
-	<div class="ui-page" data-enable-page-scroll="false" id="marqueeTest">
+	<div class="ui-page" id="marqueeTest">
 		<header class="ui-header">
 			<h2 class="ui-title">
 				Marquee

--- a/examples/wearable/UIComponents/js/circle-helper.js
+++ b/examples/wearable/UIComponents/js/circle-helper.js
@@ -14,8 +14,13 @@ document.addEventListener("tauinit", function () {
 			 * list - NodeList object for lists in the page
 			 */
 			var page = event.target,
+				pageWidget = tau.widget.Page(page),
 				pageId = page.id,
 				list;
+
+			if (pageWidget.option("enablePageScroll")) {
+				tau.util.rotaryScrolling.enable(page.querySelector(".ui-scroller"));
+			}
 
 			if (!page.classList.contains("page-snaplistview") &&
 				pageId !== "page-snaplistview" &&
@@ -26,6 +31,14 @@ document.addEventListener("tauinit", function () {
 				if (list) {
 					tau.widget.Listview(list);
 				}
+			}
+		});
+		document.addEventListener("pagebeforehide", function (event) {
+			var page = event.target,
+				pageWidget = tau.widget.Page(page);
+
+			if (pageWidget.option("enablePageScroll")) {
+				tau.util.rotaryScrolling.disable(page.querySelector(".ui-scroller"));
 			}
 		});
 	}

--- a/src/js/core/util/rotaryScrolling.js
+++ b/src/js/core/util/rotaryScrolling.js
@@ -46,10 +46,12 @@
 			 * @param {Event} event Event object
 			 */
 			function rotaryDetentHandler(event) {
-				if (event.detail.direction === "CW") {
-					element.scrollTop += scrollStep;
-				} else {
-					element.scrollTop -= scrollStep;
+				if (element.getAttribute("data-lock-rotary-scroll") !== "true") {
+					if (event.detail.direction === "CW") {
+						element.scrollTop += scrollStep;
+					} else {
+						element.scrollTop -= scrollStep;
+					}
 				}
 			}
 
@@ -76,6 +78,25 @@
 			function disable() {
 				scrollStep = 40;
 				document.removeEventListener("rotarydetent", rotaryDetentHandler);
+				element = null;
+			}
+
+			/**
+			 * Lock rotary scrolling for current scrolling container
+			 * @method lock
+			 * @memberof ns.util.rotaryScrolling
+			 */
+			function lock() {
+				element && element.setAttribute("data-lock-rotary-scroll", true);
+			}
+
+			/**
+			 * Unlock rotary scrolling for current scrolling container
+			 * @method unlock
+			 * @memberof ns.util.rotaryScrolling
+			 */
+			function unlock() {
+				element && element.removeAttribute("data-lock-rotary-scroll");
 			}
 
 			/**
@@ -100,6 +121,8 @@
 
 			rotaryScrolling.enable = enable;
 			rotaryScrolling.disable = disable;
+			rotaryScrolling.lock = lock;
+			rotaryScrolling.unlock = unlock;
 			rotaryScrolling.setScrollStep = setScrollStep;
 			rotaryScrolling.getScrollStep = getScrollStep;
 

--- a/src/js/core/widget/core/SectionChanger.js
+++ b/src/js/core/widget/core/SectionChanger.js
@@ -430,6 +430,9 @@
 					utilsEvents.on(self.scroller,
 						"swipe transitionEnd webkitTransitionEnd mozTransitionEnd msTransitionEnd oTransitionEnd", self);
 
+					// disable tau rotaryScroller, this widget has own support for rotary event
+					ns.util.rotaryScrolling && ns.util.rotaryScrolling.lock();
+
 					document.addEventListener("rotarydetent", self, true);
 				},
 
@@ -445,6 +448,9 @@
 					}
 
 					document.removeEventListener("rotarydetent", self, true);
+
+					// disable tau rotaryScroller, this widget has own support for rotary event
+					ns.util.rotaryScrolling && ns.util.rotaryScrolling.unlock();
 				},
 
 				/**

--- a/src/js/core/widget/core/VirtualListview.js
+++ b/src/js/core/widget/core/VirtualListview.js
@@ -962,6 +962,9 @@
 					utilScrolling.enable(scrollview, options.orientation);
 					utilScrolling.enableScrollBar();
 				}
+
+				// disable tau rotaryScroller the widget has own support for rotary event
+				ns.util.rotaryScrolling && ns.util.rotaryScrolling.lock();
 			};
 
 			/**

--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -1509,7 +1509,11 @@
 
 				scroller = selectorsUtil.getClosestBySelector(element, selectors.SCROLLER);
 
+
 				if (scroller) {
+					// disable tau rotaryScroller the widget has own support for rotary event
+					ns.util.rotaryScrolling && ns.util.rotaryScrolling.lock();
+
 					element.classList.add(WIDGET_CLASS, classes.PREFIX + visibleItemsCount);
 
 					self._getItemsFromElement();

--- a/src/js/profile/wearable/widget/wearable/Grid.js
+++ b/src/js/profile/wearable/widget/wearable/Grid.js
@@ -863,6 +863,9 @@
 
 				// set proper grid look
 				self.mode(options.mode);
+
+				// disable tau rotaryScroller the widget has own support for rotary event
+				ns.util.rotaryScrolling && ns.util.rotaryScrolling.lock();
 			};
 
 			function findChildIndex(self, target) {

--- a/src/js/profile/wearable/widget/wearable/Slider.js
+++ b/src/js/profile/wearable/widget/wearable/Slider.js
@@ -310,6 +310,8 @@
 
 				if (options.type === "circle") {
 					events.on(document, "rotarydetent touchstart touchmove touchend click mousedown mousemove mouseup", self, false);
+					// disable tau rotaryScroller the widget has own support for rotary event
+					ns.util.rotaryScrolling && ns.util.rotaryScrolling.lock();
 				} else {
 					CoreSliderPrototype._bindEvents.call(self);
 				}
@@ -582,6 +584,8 @@
 					self._ui = null;
 					self.options = null;
 
+					// enable tau rotaryScroller the widget has own support for rotary event
+					ns.util.rotaryScrolling && ns.util.rotaryScrolling.unlock();
 				} else {
 					CoreSliderPrototype._destroy.call(self);
 				}

--- a/src/js/profile/wearable/widget/wearable/SnapListview.js
+++ b/src/js/profile/wearable/widget/wearable/SnapListview.js
@@ -440,6 +440,9 @@
 					ui.page.querySelector(".ui-scroller") ||
 					ui.page;
 				if (scroller) {
+					// disable tau rotaryScroller the snaplistview has own support for rotary event
+					ns.util.rotaryScrolling && ns.util.rotaryScrolling.lock();
+
 					scroller.classList.add(classes.SNAP_CONTAINER);
 					ui.scrollableParent.element = scroller;
 

--- a/src/js/profile/wearable/widget/wearable/Spin.js
+++ b/src/js/profile/wearable/widget/wearable/Spin.js
@@ -505,6 +505,9 @@
 					}, ENABLING_DURATION);
 					element.classList.add(classes.ENABLED);
 					utilsEvents.on(document, "drag dragend", self);
+
+					// disable tau rotaryScroller the widget has own support for rotary event
+					ns.util.rotaryScrolling && ns.util.rotaryScrolling.lock();
 				} else {
 					element.classList.add(classes.ENABLING);
 					window.setTimeout(function () {
@@ -515,6 +518,8 @@
 					utilsEvents.off(document, "drag dragend", self);
 					// disable animation
 					self._animation.stop();
+					// enable tau rotaryScroller the widget has own support for rotary event
+					ns.util.rotaryScrolling && ns.util.rotaryScrolling.unlock();
 				}
 				// reset previous value;
 				this._prevValue = null;


### PR DESCRIPTION
[Issue] N/A
[Problem] Content in marquee page is not scrollable by bezel
[Solution] Added new public methods for rotaryScrolling.
 New methods allows widget to block rotary scroll util
 when the widget has own support for rotary event

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>