### PR TITLE
UIComponents: fix for circle-helper for support bezel in popup content

### DIFF
--- a/examples/wearable/UIComponents/js/circle-helper.js
+++ b/examples/wearable/UIComponents/js/circle-helper.js
@@ -41,5 +41,13 @@ document.addEventListener("tauinit", function () {
 				tau.util.rotaryScrolling.disable(page.querySelector(".ui-scroller"));
 			}
 		});
+		document.addEventListener("popupshow", function (event) {
+			var popup = event.target;
+
+			tau.util.rotaryScrolling.enable(popup.querySelector(".ui-popup-wrapper"));
+		});
+		document.addEventListener("popuphide", function () {
+			tau.util.rotaryScrolling.disable();
+		});
 	}
 });


### PR DESCRIPTION
[Issue] N/A
[Problem] Popup content is not scrolled by bezel
[Solution] Rotary scrolling has been enabled on popup content
