### PR TITLE
Marquee: Deprecated value 'ellipsis' for option 'ellipsisEffect'

### DIFF
--- a/examples/wearable/UIComponents/contents/controls/marquee/index.html
+++ b/examples/wearable/UIComponents/contents/controls/marquee/index.html
@@ -36,9 +36,6 @@
 			<div class="ui-marquee ui-marquee-gradient" data-iteration="10" data-marquee-style="slide" id="marquee2">
 				Marquee SLIDE TEST TEST message TEST for marquee MarqueeTEST TEST message TEST for marquee MarqueeTEST TEST message TEST for marquee MarqueeTEST TEST message TEST for marquee
 			</div>
-			<div class="ui-marquee ui-marquee-ellipsis" data-delay="1000" data-iteration="10" data-marquee-style="scroll" id="marquee5">
-				Marquee SCROLL ellipsis TEST TEST message TEST for marquee MarqueeTEST TEST message TEST for marquee MarqueeTEST TEST message TEST for marquee MarqueeTEST TEST message TEST for marquee
-			</div>
 		</div>
 		<footer class="ui-footer ui-bottom-button ui-fixed">
 			<a class="ui-btn" href="#" id="start">

--- a/src/js/core/widget/core/Marquee.js
+++ b/src/js/core/widget/core/Marquee.js
@@ -167,7 +167,7 @@
 
 				ellipsisEffect = {
 					GRADIENT: "gradient",
-					ELLIPSIS: "ellipsis",
+					ELLIPSIS: "ellipsis", // deprecated effect
 					NONE: "none"
 				},
 
@@ -186,7 +186,7 @@
 				 * @property {number} [options.delay=2000] Sets the delay(ms) for marquee
 				 * @property {"linear"|"ease"|"ease-in"|"ease-out"|"cubic-bezier(n,n,n,n)"}
 				 * [options.timingFunction="linear"] Sets the timing function for marquee
-				 * @property {"gradient"|"ellipsis"|"none"} [options.ellipsisEffect="gradient"] Sets the
+				 * @property {"gradient"|"none"} [options.ellipsisEffect="gradient"] Sets the
 				 * end-effect(gradient) of marquee
 				 * @property {boolean} [options.autoRun=true] Sets the status of autoRun
 				 * @member ns.widget.core.Marquee
@@ -298,7 +298,7 @@
 				return returnValue;
 			};
 
-			prototype._calculateStandardGradient = function (state, diff, from, current) {
+			prototype._calculateStandardGradient = function (state) {
 				var returnValue;
 
 				if (isNaN(state)) {
@@ -329,6 +329,13 @@
 				var marqueeInnerElement = element.querySelector("." + classes.MARQUEE_CONTENT);
 
 				element.classList.add(CLASSES_PREFIX);
+
+				// check deprecated class
+				if (element.classList.contains(classes.MARQUEE_ELLIPSIS)) {
+					ns.warn("Class '" + classes.MARQUEE_ELLIPSIS +
+						"' for option 'ellipsisEffect' in Marquee widget has been deprecated. " +
+						"Allowed values: none, '" + classes.MARQUEE_GRADIENT + "' (default)");
+				}
 
 				if (!marqueeInnerElement) {
 					marqueeInnerElement = document.createElement("div");
@@ -418,6 +425,9 @@
 			};
 
 			prototype._setEllipsisEffect = function (element, value) {
+				if (value === "ellipsis") {
+					ns.warn("Marquee: option value 'ellipsis' for 'ellipsisEffect' is deprecated. Allowed values: 'none', 'gradient' (default)");
+				}
 				return this._togglePrefixedClass(this._stateDOM, CLASSES_PREFIX + "-", value);
 			};
 


### PR DESCRIPTION
[Issue] N/A
[Problem] Marquee with ellipsis is not supported
[Solution]
 - Removing example of marquee with ellipsis
 - added Debug warning about deprecated ellipsis option

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>