### PR TITLE
(UIComponents) SnapListView: fix for wrong selection on rotary scrolling

### DIFF
--- a/examples/wearable/UIComponents/js/circle-helper.js
+++ b/examples/wearable/UIComponents/js/circle-helper.js
@@ -32,7 +32,7 @@ document.addEventListener("tauinit", function () {
 					tau.widget.Listview(list);
 				}
 			}
-		});
+		}, true);
 		document.addEventListener("pagebeforehide", function (event) {
 			var page = event.target,
 				pageWidget = tau.widget.Page(page);


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/561
[Problem] SnapListView + rotary scrolling - wrong selection position
[Solution] The Snaplistview example has two listeners on "pagebeforeshow".
Listener from circular-helper was called after listener from snaplistview.js.
This cause issue with locking of rotaryScroll when rotary scroll was not
enabled yet.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>