### PR TITLE
ArcListview: fix showing selection on click while scrolling

### DIFF
--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -1351,9 +1351,10 @@
 					if (toIndex < state.items.length) {
 						state.toIndex = toIndex;
 					}
-
-					self._roll();
 				}
+				// Do scroll regardless of 'toIndex' value. This will center content relative
+				// to clicked position.
+				self._roll();
 			};
 
 			prototype._onPageInit = function () {


### PR DESCRIPTION
Issue: N/A

Problem: middle item does not fit to selection on click while scrolling
Cause: no scoll update if clicked position happens on currently selected item
Solution: Do scroll regardless of 'toIndex' value.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>