### PR TITLE
ArcListview: do not show selection while scrolling

### DIFF
--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -511,10 +511,14 @@
 						1
 					);
 					if (self._scrollAnimationEnd) {
-						self.trigger(events.CHANGE, {
-							"selected": state.currentIndex
-						});
-						eventUtils.trigger(state.items[state.currentIndex].element, "selected");
+						// _scrollAnimationEnd can be set by TouchStart event to stop scroll.
+						// Show selection if scroll finishes.
+						if (deltaTime >= state.duration) {
+							self.trigger(events.CHANGE, {
+								"selected": state.currentIndex
+							});
+							eventUtils.trigger(state.items[state.currentIndex].element, "selected");
+						}
 						state.toIndex = state.currentIndex;
 
 						// set last scroll position when current page is hidden
@@ -1192,6 +1196,8 @@
 					if (bouncingEffect) {
 						bouncingEffect.dragEnd();
 					}
+				} else {
+					self._roll();
 				}
 			};
 


### PR DESCRIPTION
Issue: https://github.com/Samsung/TAU/issues/566

Problem: stopping fast scroll by pressing finger causes
	selection at wrong position.

Cause: scrollAnimationEnd variable is also set on TouchStart event
	to indicate that current animation should end.
	But in fact we are in the middle of animation.

Solution: show selection only if scroll finishes regardless of scrollAnimationEnd.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>