### PR TITLE
fixup! (UIComponents) SnapListView: fix for wrong selection on rotary

### DIFF
--- a/examples/wearable/UIComponents/js/circle-helper.js
+++ b/examples/wearable/UIComponents/js/circle-helper.js
@@ -26,7 +26,8 @@ document.addEventListener("tauinit", function () {
 				pageId !== "page-snaplistview" &&
 				pageId !== "page-swipelist" &&
 				pageId !== "page-marquee-list" &&
-				pageId !== "page-multiline-list") {
+				pageId !== "page-multiline-list" &&
+				pageId !== "drawer-page") {
 				list = page.querySelector(".ui-listview");
 				if (list) {
 					tau.widget.Listview(list);


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/569
[Problem] Drawer example shows list items on the start
[Solution] Avoid list creation on drawer initialization.
This is fix for regression after 9f972ce

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>