### PR TITLE
Move variable declarations before their usage

### DIFF
--- a/src/js/core/util/deferredWhen.js
+++ b/src/js/core/util/deferredWhen.js
@@ -32,6 +32,9 @@
 				var i = 0,
 					resolveValues = [].slice.call(arguments),
 					length = resolveValues.length,
+					progressValues,
+					progressContexts,
+					resolveContexts,
 
 					/**
 					 * The count of uncompleted subordinates
@@ -72,11 +75,7 @@
 								deferred.resolveWith(contexts, values);
 							}
 						};
-					},
-
-					progressValues,
-					progressContexts,
-					resolveContexts;
+					};
 
 				// add listeners to Deferred subordinates; treat others as resolved
 				if (length > 1) {

--- a/src/js/core/widget/core/Popup.js
+++ b/src/js/core/widget/core/Popup.js
@@ -101,32 +101,6 @@
 
 				POPUP_SELECTOR = "[data-role='popup'], .ui-popup",
 
-				Popup = function () {
-					var self = this,
-						ui = {};
-
-					self.selectors = selectors;
-					self.options = objectUtils.merge({}, Popup.defaults);
-					self.storedOptions = null;
-					/**
-					 * Popup state flag
-					 * @property {0|1|2|3} [state=null]
-					 * @member ns.widget.core.Popup
-					 * @private
-					 */
-					self.state = states.CLOSED;
-
-					ui.overlay = null;
-					ui.header = null;
-					ui.footer = null;
-					ui.content = null;
-					ui.container = null;
-					ui.wrapper = null;
-					self._ui = ui;
-
-					// event callbacks
-					self._callbacks = {};
-				},
 				/**
 				 * Object with default options
 				 * @property {Object} defaults
@@ -293,6 +267,33 @@
 					 */
 					before_hide: EVENTS_PREFIX + "beforehide"
 					/* eslint-enable camelcase */
+				},
+
+				Popup = function () {
+					var self = this,
+						ui = {};
+
+					self.selectors = selectors;
+					self.options = objectUtils.merge({}, Popup.defaults);
+					self.storedOptions = null;
+					/**
+					 * Popup state flag
+					 * @property {0|1|2|3} [state=null]
+					 * @member ns.widget.core.Popup
+					 * @private
+					 */
+					self.state = states.CLOSED;
+
+					ui.overlay = null;
+					ui.header = null;
+					ui.footer = null;
+					ui.content = null;
+					ui.container = null;
+					ui.wrapper = null;
+					self._ui = ui;
+
+					// event callbacks
+					self._callbacks = {};
 				},
 
 				prototype = new BaseWidget();


### PR DESCRIPTION
[Issue] N/A
[Problem] Sonar reported issues:
Move the declaration of "states" before this usage.
Move the declaration of "selectors" before this usage.
Move the declaration of "progressValues" before this usage.
[Solution] Move declarations

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>