### PR TITLE
Remove duplicated assignements

### DIFF
--- a/src/js/core/util/anchorHighlight.js
+++ b/src/js/core/util/anchorHighlight.js
@@ -504,11 +504,9 @@
 			anchorHighlight._clearActiveClass = clearActiveClass;
 			anchorHighlight._detectHighlightTarget = detectHighlightTarget;
 			anchorHighlight._detectBtnElement = detectBtnElement;
-			anchorHighlight._clearBtnActiveClass = clearBtnActiveClass;
 			anchorHighlight._removeActiveClassLoop = removeActiveClassLoop;
 			anchorHighlight._addButtonInactiveClass = addButtonInactiveClass;
 			anchorHighlight._addButtonActiveClass = addButtonActiveClass;
-			anchorHighlight._hideClear = hideClear;
 			anchorHighlight._addActiveClass = addActiveClass;
 			anchorHighlight._detectLiElement = detectLiElement;
 			anchorHighlight._touchmoveHandler = touchmoveHandler;


### PR DESCRIPTION
[Issue] N/A
[Problem] Sonar reported issues:
Verify this is the index that was intended; '_clearBtnActiveClass' was already set on line 507.
Verify this is the index that was intended; '_hideClear' was already set on line 511.
[Solution] Removed duplicate assignements

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>