### PR TITLE
(SVACE) Gruntfile: fix for unconsistently "return" use

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,6 +137,7 @@ module.exports = function (grunt) {
 							};
 						}
 					}
+					return null;
 				},
 
 				getLicenseFiles: function (version) {
@@ -1243,6 +1244,7 @@ module.exports = function (grunt) {
 				);
 			}
 			callback(error);
+			return null;
 		});
 
 		jsduck.stdout.pipe(process.stdout);


### PR DESCRIPTION
[Issue] SVACE 559589, 559590
[Problem] Function doesn't "return" consistently
[Solution]
 - 559589 - fix for "return" in css method
 - 559590 - fix for "return" in jsduck callback

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>