### PR TITLE
(SVACE) engine.js: fix expression for element always evaluate to true

### DIFF
--- a/src/js/core/engine.js
+++ b/src/js/core/engine.js
@@ -337,7 +337,7 @@
 						return getInstanceByElement(binding, element, type);
 					} else {
 						// Check if widget has wrapper and find base element
-						if (element && typeof element.hasAttribute === TYPE_FUNCTION &&
+						if (typeof element.hasAttribute === TYPE_FUNCTION &&
 								element.hasAttribute(DATA_WIDGET_WRAPPER)) {
 							baseElement = slice.call(element.children).filter(filterBuiltWidget)[0];
 							if (baseElement) {


### PR DESCRIPTION
    (SVACE) engine.js: fix expression for element always evaluate to true
    
    [Issue] SVACE 560208
    [Problem] Refactor this code so that this expression does not always
     evaluate to true.
    [Solution]
     - 560208 - element has been removed from expression
    
    Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>
