### PR TITLE
(SVACE) vmouse: added 'return' on end of function

### DIFF
--- a/src/js/core/event/vmouse.js
+++ b/src/js/core/event/vmouse.js
@@ -272,6 +272,7 @@
 				if (!x && !y) {
 					return preparePositionForEvent(event);
 				}
+				return null;
 			}
 
 			/**


### PR DESCRIPTION
[Issue] svace 560212
[Problem] function doesn't use "return" consistently.
[Solution] The "return" has been added on the end of function

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>