### PR TITLE
(SVACE) history manager: fix for expression evaluated always true

### DIFF
--- a/src/js/core/history/manager.js
+++ b/src/js/core/history/manager.js
@@ -126,7 +126,7 @@
 						if (href && !options.href) {
 							options.href = href;
 						}
-						if (rel === "popup" && link && !options.link) {
+						if (rel === "popup" && !options.link) {
 							options.link = link;
 						}
 						history.disableVolatileMode();


### PR DESCRIPTION
[Issue] svac 560213
[Problem] the expression always evaluate to true.
[Solution] The expression has been reduced

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>