### PR TITLE
(SVACE) support: remove redundant assignment for pointerEvents

### DIFF
--- a/src/js/core/support.js
+++ b/src/js/core/support.js
@@ -209,7 +209,6 @@
 					return false;
 				}
 
-				elementStyle.pointerEvents = "auto";
 				elementStyle.pointerEvents = "x";
 				documentElement.appendChild(element);
 				supports = getComputedStyle && getComputedStyle(element, "").pointerEvents === "auto";


### PR DESCRIPTION
[Issue] svace 560215
[Problem] The 'pointerEvents' was already set on line before.
[Solution] Redundant assignment has been removed

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>