### PR TITLE
(SVACE) BaseWidget: added "return" at the end of "trigger" methods

### DIFF
--- a/src/js/core/widget/BaseWidget.js
+++ b/src/js/core/widget/BaseWidget.js
@@ -1019,6 +1019,7 @@
 				if (this.element) {
 					return eventUtils.trigger(this.element, eventName, data, bubbles, cancelable);
 				}
+				return false;
 			};
 
 			/**


### PR DESCRIPTION
[Issue] svace 560226
[Problem] Refactor this function to use "return" consistently.
[Solution] The "return" statement has been added to trigger method

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>