### PR TITLE
(SVACE) Scrollview: add return at the end of findPositionAnchor method

### DIFF
--- a/src/js/core/widget/core/Scrollview.js
+++ b/src/js/core/widget/core/Scrollview.js
@@ -832,6 +832,8 @@
 						if (id && ["input", "textarea", "button"].indexOf(tagName) > -1) {
 							return input.parentNode.querySelector("label[for=" + id + "]");
 						}
+
+						return null;
 					},
 					_true = true;
 


### PR DESCRIPTION
Issue: svace 560236
Problem: refactor this function to use "return" consistently
Solution: add return at the end of findPositionAnchor method

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>