### PR TITLE
(SVACE) PageIndicator: the option "intervalAngle" must be a number

### DIFF
--- a/src/js/core/widget/core/PageIndicator.js
+++ b/src/js/core/widget/core/PageIndicator.js
@@ -190,7 +190,7 @@
 				var self = this,
 					items = element.children,
 					numberOfDots = items.length,
-					intervalAngle = self.options.intervalAngle - "0",
+					intervalAngle = parseFloat(self.options.intervalAngle),
 					translatePixel,
 					style,
 					i;


### PR DESCRIPTION
[Issue] svace 560232
[Problem] Convert this operand into a number
[Solution] The number conversion has been changed to "parseFloat"

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>