### PR TITLE
(SVACE) Scroller: removing redundant assignment

### DIFF
--- a/src/js/core/widget/core/scroller/Scroller.js
+++ b/src/js/core/widget/core/scroller/Scroller.js
@@ -218,9 +218,6 @@
 				var elementStyle = this.element.style,
 					scrollerStyle = this.scrollerStyle;
 
-				elementStyle.overflow = "";
-				elementStyle.position = "";
-
 				elementStyle.overflow = "hidden";
 				elementStyle.position = "relative";
 


### PR DESCRIPTION
[Issue] svace 560238, 560239
[Problem] Property 'position' and 'overflow' was already set
[Solution] Removing reduntant assignment

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>