### PR TITLE
(SVACE) ArcListview: use "return" consistently

### DIFF
--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -480,6 +480,8 @@
 						return null;
 					}
 				}
+
+				return null;
 			}
 
 			/**
@@ -893,7 +895,7 @@
 					scroll = state.scroll;
 
 				if (state.items.length === 0) {
-					return false;
+					return;
 				}
 
 				// increase scroll duration according to length of items
@@ -1128,7 +1130,7 @@
 					bouncingEffect = self._bouncingEffect;
 
 				if (self._items.length === 0) {
-					return false;
+					return;
 				}
 
 				// time


### PR DESCRIPTION
Issue: svace 560243, 562149, 562150
Problem: Refactor this function to use "return" consistently.
Solution:
    add return at the end of _getSeparatorBeforeListItem method
    remove return from _roll() and _onTouchMove functions since it is useless
 
Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>