### PR TITLE
(SVACE) Datetimepicker: Remove unnecessary return

### DIFF
--- a/src/js/profile/wearable/widget/wearable/Datetimepicker.js
+++ b/src/js/profile/wearable/widget/wearable/Datetimepicker.js
@@ -118,7 +118,6 @@
 			 *
 			 * @param {ns.widget.wearable.Datetimepicker} self
 			 * @param {Event} event
-			 * @return {null}
 			 */
 			function handleWheelButtons(self, event) {
 				var button = event.target,
@@ -135,7 +134,7 @@
 					direction = -1;
 					// Everything else than minus / plus button should be ignored
 				} else if (!buttonClassList.contains(classes.uiDatetimeWheelPlus)) {
-					return null;
+					return;
 				}
 
 				switch (activeField.dataset.fieldName) {
@@ -176,7 +175,6 @@
 				}
 
 				self._setDateFields(currentDate);
-				return null;
 			}
 
 			function handlePeriodButtons(self, event) {


### PR DESCRIPTION
Issue: svace 560246
Problem: Refactor this method to not always return the same value.
Solution: Remove return statement since it's useless

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>