### PR TITLE
(SVACE) Slider: added "return" to "_setValue" method

### DIFF
--- a/src/js/profile/wearable/widget/wearable/Slider.js
+++ b/src/js/profile/wearable/widget/wearable/Slider.js
@@ -527,6 +527,7 @@
 				} else {
 					return CoreSliderPrototype._setValue.call(self, value);
 				}
+				return null;
 			};
 
 			/**


### PR DESCRIPTION
[Issue] svace 560249
[Problem] Refactor this function to use "return" consistently.
[Solution] Added missing "return null" at the end of method

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>