### PR TITLE
(SVACE) performance: add return at the end of get function

### DIFF
--- a/src/js/tools/performance.js
+++ b/src/js/tools/performance.js
@@ -86,6 +86,7 @@
 
 						return text;
 					}
+					return null;
 				},
 				finish: function () {
 					var self = this;


### PR DESCRIPTION
Issue: svace 560273
Problem: Refactor this function to use "return" consistently.
Solution: add return at the end of get function

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>