### PR TITLE
(SVACE) ToggleSwitch.extra: remove unreachable code

### DIFF
--- a/src/js/support/mobile/widget/ToggleSwitch.extra.js
+++ b/src/js/support/mobile/widget/ToggleSwitch.extra.js
@@ -534,9 +534,6 @@
 
 					// If changes came from input value change
 				} else {
-					if (value === null) {
-						value = getInitialValue(tagName, control);
-					}
 					if (isNaN(value)) {
 						return;
 					}


### PR DESCRIPTION
Issue: svace 560271, 560272
Problem: Change this condition so that it does not always evaluate to "false"
Solution: remove this code due it's never called. In js, typeof null is equal to
	object and null will be handled in above condition.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>