### PR TITLE
(SVACE) Datetimepicker: omit number conversion to string

### DIFF
--- a/src/js/support/mobile/widget/Datetimepicker.js
+++ b/src/js/support/mobile/widget/Datetimepicker.js
@@ -127,10 +127,6 @@
 					return;
 				}
 
-				if (value === 0) {
-					value = "0";
-				}
-
 				pat = dom.getNSData(target, "pat");
 				targetClassList = target.classList;
 
@@ -143,12 +139,11 @@
 						if (pat.charAt(0) === "h") {
 							if (hour > 12) {
 								hour -= 12;
-							} else if (hour === "0") {
+							} else if (hour === 0) {
 								hour = 12;
 							}
 						}
-						hour = makeTwoDigits(hour);
-						text = hour;
+						text = makeTwoDigits(hour);
 						break;
 					case "m":
 					case "M":
@@ -173,13 +168,12 @@
 						break;
 					case "yyyy":
 						if (value < 10) {
-							value = "000" + value;
+							text = "000" + value;
 						} else if (value < 100) {
-							value = "00" + value;
+							text = "00" + value;
 						} else if (value < 1000) {
-							value = "0" + value;
+							text = "0" + value;
 						}
-						text = value;
 						break;
 					case "t":
 					case "tt":


### PR DESCRIPTION
Issue: svace 560253, 560254, 560255, 560256, 560257, 560258, 560259, 560260
Problem: Convert this operand into a number.
Solution: let updateField() function operate on number instead of string

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>