### PR TITLE
(tests) Page: update for tests of Title in AppBar 

### DIFF
--- a/tests/js/core/widget/core/Page/Page.js
+++ b/tests/js/core/widget/core/Page/Page.js
@@ -598,8 +598,6 @@
 		});
 
 		test("_setTitle", function () {
-			ok(true, "Test disabled");
-			/* test disabled
 			var pageElement = document.getElementById("title-h1"),
 				pageWidget = new Page(),
 				ui = {
@@ -609,7 +607,7 @@
 			pageWidget._ui = ui;
 			pageWidget._setTitle(pageElement);
 			equal(pageElement.dataset.title, "Header", "title was found");
-			equal(ui.title, ui.header.children[0], "title was found");
+			equal(ui.title, ui.header.querySelector(".ui-appbar-title"), "title was found");
 
 			pageElement = document.getElementById("title-h6");
 			pageWidget = new Page();
@@ -620,7 +618,7 @@
 			pageWidget._ui = ui;
 			pageWidget._setTitle(pageElement);
 			equal(pageElement.dataset.title, "Header", "title was found");
-			equal(ui.title, ui.header.children[0], "title was found");
+			equal(ui.title, ui.header.querySelector(".ui-appbar-title"), "title was found");
 
 			pageElement = document.getElementById("data-title");
 			pageWidget = new Page();
@@ -632,7 +630,6 @@
 			pageWidget._setTitle(pageElement);
 			equal(pageElement.dataset.title, "title", "title was found");
 			equal(ui.title, undefined, "title was not found");
-			*/
 		});
 
 

--- a/tests/js/core/widget/core/Page/mobile/page.js
+++ b/tests/js/core/widget/core/Page/mobile/page.js
@@ -33,15 +33,11 @@ test("Page DOM created", function () {
 });
 
 test("Page titles", function () {
-	ok(true, "Test disabled");
-	/*
-	var h1 = document.getElementById("h1"),
-		h2 = document.getElementById("h2");
+	var h1 = document.getElementById("h1");
 
 	$("#page1").page();
-	ok(h1.classList.contains("ui-title"), "Title has been enhanced");
+	ok(h1.classList.contains("ui-appbar-title"), "Title has been enhanced");
 	equal(h1.getAttribute("role"), "heading");
 	equal(h1.getAttribute("aria-level"), "1");
 	equal(h1.getAttribute("aria-label"), "title");
-	*/
 });


### PR DESCRIPTION
(tests) Page: update for tests of Title in AppBar
   
[Issue] https://github.com/Samsung/TAU/issues/619
[Problem] (test fail) Page widget
[Solution] Structure of Title in Page for OneUI has been changed.
  The tests required update.