### PR TITLE
Restore ui-title class creation

### DIFF
--- a/src/js/core/widget/core/Page.js
+++ b/src/js/core/widget/core/Page.js
@@ -789,7 +789,8 @@
 					}
 
 					arrayUtil.forEach(titleElements, function (titleElement) {
-						// TODO: Create another widget for appbar
+						// TODO: Create another widget for appbar on mobile
+						titleElement.classList.add(classes.uiTitle);
 						titleElement.classList.add(classes.uiAppbarTitle);
 						titleContainer.appendChild(titleElement);
 					});


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/632
[Problem] Header in sample app for wearable is too large.

[Cause] Mobile profile implementation removed uititle class creation when
only header is used in example
[Solution] Restore ui-title class creation

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>