### PR TITLE
Fix ArcListView layout for multiline items

### DIFF
--- a/examples/wearable/UIComponents/contents/list/arclist_marquee_style.html
+++ b/examples/wearable/UIComponents/contents/list/arclist_marquee_style.html
@@ -27,7 +27,7 @@
 			<ul class="ui-listview expand-list" id="snapList">
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient ui-li-anchor">
-						1.SnapListview with Marquee SnapListview with Marquee
+						1.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -35,7 +35,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						2.SnapListview with Marquee SnapListview with Marquee
+						2.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -43,7 +43,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						3.SnapListview with Marquee SnapListview with Marquee
+						3.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -51,7 +51,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						4.SnapListview with Marquee SnapListview with Marquee
+						4.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -59,7 +59,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						5.SnapListview with Marquee SnapListview with Marquee
+						5.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -67,7 +67,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						6.SnapListview with Marquee SnapListview with Marquee
+						6.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -75,7 +75,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						7.SnapListview with Marquee SnapListview with Marquee
+						7.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -83,7 +83,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						8.SnapListview with Marquee SnapListview with Marquee
+						8.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -91,7 +91,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						9.SnapListview with Marquee SnapListview with Marquee
+						9.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -99,7 +99,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						10.SnapListview with Marquee SnapListview with Marquee
+						10.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -107,7 +107,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						11.SnapListview with Marquee SnapListview with Marquee
+						11.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -115,7 +115,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						12.SnapListview with Marquee SnapListview with Marquee
+						12.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -123,7 +123,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						13.SnapListview with Marquee SnapListview with Marquee
+						13.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -131,7 +131,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						14.SnapListview with Marquee SnapListview with Marquee
+						14.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -139,7 +139,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						15.SnapListview with Marquee SnapListview with Marquee
+						15.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -147,7 +147,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						16.SnapListview with Marquee SnapListview with Marquee
+						16.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -155,7 +155,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						17.SnapListview with Marquee SnapListview with Marquee
+						17.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -163,7 +163,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						18.SnapListview with Marquee SnapListview with Marquee
+						18.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -171,7 +171,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						19.SnapListview with Marquee SnapListview with Marquee
+						19.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text
@@ -179,7 +179,7 @@
 				</li>
 				<li class="li-has-multiline">
 					<div class="ui-marquee ui-marquee-gradient">
-						20.SnapListview with Marquee SnapListview with Marquee
+						20.ArcListView with Marquee ArcListView with Marquee
 					</div>
 					<div class="li-text-sub ui-li-sub-text">
 						sub-text

--- a/src/css/profile/wearable/changeable/theme-circle/listview.less
+++ b/src/css/profile/wearable/changeable/theme-circle/listview.less
@@ -351,7 +351,9 @@
 	}
 	&.ui-arc-listview-carousel-item:not(.ui-snap-listview) {
 		li {
-			flex-direction: row;
+			&:not(.ui-li-has-multiline):not(.li-has-multiline) {
+				flex-direction: row;
+			}
 		}
 	}
 


### PR DESCRIPTION
[Issue] #636
[Problem] ArcListView multiline items have broken layout.
[Reason] Row layout is applied for items
[Solution] Apl solution similar to snaplist view
for multiline items use default column layout
[Remark]
Issue was introduced in a3ca836 but after further changes row layout is
effective because of 76ede39
[Test]
List > Marquee List > Obs
ArcListview > ArcListview > Obs
Control > radio > Obs
Control > Slider > Obs

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com