### PR TITLE
Don't call window.history.back in sample UIComponents app

### DIFF
--- a/examples/mobile/UIComponents/.tproject
+++ b/examples/mobile/UIComponents/.tproject
@@ -2,7 +2,7 @@
 <tproject xmlns="http://www.tizen.org/tproject">
     <platforms>
         <platform>
-            <name>wearable-5.5</name>
+            <name>mobile-5.5</name>
         </platform>
     </platforms>
     <package>

--- a/examples/mobile/UIComponents/js/app.js
+++ b/examples/mobile/UIComponents/js/app.js
@@ -14,8 +14,6 @@
 					tizen.application.getCurrentApplication().exit();
 				} catch (ignore) {
 				}
-			} else {
-				window.history.back();
 			}
 		}
 	});

--- a/examples/wearable/UIComponents/config.xml
+++ b/examples/wearable/UIComponents/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<widget xmlns="http://www.w3.org/ns/widgets" xmlns:tizen="http://tizen.org/ns/widgets" id="http://sample-web-application.tizen.org/UIComponents" version="1.0.0" viewmodes="fullscreen">
+<widget xmlns:tizen="http://tizen.org/ns/widgets" xmlns="http://www.w3.org/ns/widgets" id="http://sample-web-application.tizen.org/UIComponents" version="1.0.0" viewmodes="fullscreen">
     <tizen:application id="1234567890.UIComponents" package="1234567890" required_version="2.3.2"/>
     <content src="index.html"/>
     <feature name="http://tizen.org/feature/screen.size.normal"/>

--- a/examples/wearable/UIComponents/js/app.js
+++ b/examples/wearable/UIComponents/js/app.js
@@ -14,8 +14,6 @@
 					tizen.application.getCurrentApplication().exit();
 				} catch (ignore) {
 				}
-			} else {
-				window.history.back();
 			}
 		}
 	});


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/663
[Problem] On 5.5 emulator using HW back key cause going back two times
On 5.0 emulator there is no such issue
[Reason] Tizen 5.5 emulator has alread build-in feature for web apps to call window.history.back
No need to call it by sample app
[Solution] Remove calling window.history.back from helper file
Update samples base version to 5.5

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>