### PR TITLE
Content: show bouncing effect on rotary

### DIFF
--- a/src/js/core/util/rotaryScrolling.js
+++ b/src/js/core/util/rotaryScrolling.js
@@ -39,18 +39,41 @@
 				 * Scroll step
 				 * @type {number}
 				 */
-				scrollStep = 40;
+				scrollStep = 40,
+				/**
+				 * Time after bound effect will be hidden.
+				 * @type {number}
+				 */
+				BOUNCING_TIMEOUT = 1000;
 
 			/**
 			 * Handler for rotary event
 			 * @param {Event} event Event object
 			 */
 			function rotaryDetentHandler(event) {
+				var scrollview = null,
+					maxScrollY = 0;
+
 				if (element.getAttribute("data-lock-rotary-scroll") !== "true") {
+					scrollview = ns.engine.getBinding(element.parentElement, "Scrollview");
 					if (event.detail.direction === "CW") {
 						element.scrollTop += scrollStep;
+						if (scrollview) {
+							maxScrollY = element.scrollTop + window.innerHeight;
+							scrollview.bouncingEffect.drag(undefined /* ignore horizontal effect */, -maxScrollY);
+						}
 					} else {
 						element.scrollTop -= scrollStep;
+						if (scrollview) {
+							scrollview.bouncingEffect.drag(undefined /* ignore horizontal effect */, element.scrollTop);
+						}
+					}
+
+					// Hide bouncing after timeout.
+					if (scrollview) {
+						setTimeout(function () {
+							scrollview.bouncingEffect.dragEnd();
+						}, BOUNCING_TIMEOUT);
 					}
 				}
 			}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/629
[Problem] There is no bouncing effect on rotary whereas
	on scroll it is shown. According to guide, scoll and rotary
	events should behave in the same way on content element.
[Solution] show bouncing effect on rotary event.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>