### PR TITLE
Use direct parameter to set scrolled on true in case of rotary event

### DIFF
--- a/src/js/core/widget/core/SectionChanger.js
+++ b/src/js/core/widget/core/SectionChanger.js
@@ -464,8 +464,10 @@
 
 					switch (event.type) {
 						case "swipe":
-						case "rotarydetent" :
 							this._change(event);
+							break;
+						case "rotarydetent" :
+							this._change(event, true);
 							break;
 						case "webkitTransitionEnd":
 						case "mozTransitionEnd":
@@ -502,17 +504,24 @@
 				 * Changes the currently active section element.
 				 * @method setActiveSection
 				 * @param {number} index
-				 * @param {number} duration For smooth scrolling,
+				 * @param {number} [duration=0] For smooth scrolling,
 				 * the duration parameter must be in milliseconds.
-				 * @param {number} [direct=false]
+				 * @param {number} [direct=false] Whether section is set once directly (e.g. with bezel)
+				 *  or with touch events
 				 * @member ns.widget.core.SectionChanger
 				 */
 				setActiveSection: function (index, duration, direct) {
 					var position = this.sectionPositions[index],
-						scrollbarDuration = duration,
+						scrollbarDuration,
 						oldActiveIndex = this.activeIndex,
 						newX = 0,
 						newY = 0;
+
+					//default parameters
+					duration = duration || 0;
+					direct = !!direct;
+
+					scrollbarDuration = duration;
 
 					if (this.orientation === Orientation.HORIZONTAL) {
 						newX = this._sectionChangerHalfWidth - calculateCenter(this.orientation, this.sections, position);
@@ -605,11 +614,20 @@
 					}
 				},
 
-				_change: function (event) {
+				/**
+				 * Changes the currently active section element.
+				 * @method _change
+				 * @param {event} event
+				 * @param {boolean} [direct=false]
+				 * @private
+				 */
+				_change: function (event, direct) {
 					var self = this,
 						direction = event.detail.direction,
 						offset = direction === gesture.Direction.UP || direction === gesture.Direction.LEFT || direction === "CW" ? 1 : -1,
 						newIndex = self._calculateIndex(self.beforeIndex + offset);
+
+					direct = !!direct;
 
 					if (self.enabled && !self.scrollCanceled) {
 						// bouncing effect
@@ -622,7 +640,7 @@
 							self._notifyChangedSection(newIndex);
 						}
 
-						self.setActiveSection(newIndex, self.options.animateDuration, false);
+						self.setActiveSection(newIndex, self.options.animateDuration, direct);
 						self.dragging = false;
 					}
 				},


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/659
[Problem] When rotating with bezel strange animation occurs in section changer
[Solution] Use direct parameter which sets scrolled value to true in setActiveSection.
This will allow to reposition sections in _endScroll in case of rotarydetent event.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>