### PR TITLE
Reposition sections when setActiveSection API is called by app creator

### DIFF
--- a/src/js/core/widget/core/SectionChanger.js
+++ b/src/js/core/widget/core/SectionChanger.js
@@ -241,7 +241,7 @@
 						self._initLayout();
 						self._super(element);
 						self._repositionSections(true);
-						self.setActiveSection(self.activeIndex);
+						self.setActiveSection(self.activeIndex, 0, false, false);
 
 						// set correct options values.
 						if (!options.animate) {
@@ -506,11 +506,12 @@
 				 * @param {number} index
 				 * @param {number} [duration=0] For smooth scrolling,
 				 * the duration parameter must be in milliseconds.
-				 * @param {number} [direct=false] Whether section is set once directly (e.g. with bezel)
+				 * @param {boolean} [direct=false] Whether section is set once directly (e.g. with bezel)
 				 *  or with touch events
+				 * @param {boolean} [reposition=true] Whether sections should be repositioned
 				 * @member ns.widget.core.SectionChanger
 				 */
-				setActiveSection: function (index, duration, direct) {
+				setActiveSection: function (index, duration, direct, reposition) {
 					var position = this.sectionPositions[index],
 						scrollbarDuration,
 						oldActiveIndex = this.activeIndex,
@@ -520,6 +521,9 @@
 					//default parameters
 					duration = duration || 0;
 					direct = !!direct;
+					if (reposition == undefined) {
+						reposition = true;
+					}
 
 					scrollbarDuration = duration;
 
@@ -553,6 +557,11 @@
 					if (this.activeIndex !== oldActiveIndex) {
 						this._notifyChangedSection(this.activeIndex);
 					}
+
+					if (reposition) {
+						this._repositionSections(true);
+					}
+
 				},
 
 				/**
@@ -609,7 +618,7 @@
 							self.bouncingEffect.dragEnd();
 						}
 
-						self.setActiveSection(self.activeIndex, self.options.animateDuration, false);
+						self.setActiveSection(self.activeIndex, self.options.animateDuration, false, false);
 						self.dragging = false;
 					}
 				},
@@ -640,7 +649,7 @@
 							self._notifyChangedSection(newIndex);
 						}
 
-						self.setActiveSection(newIndex, self.options.animateDuration, direct);
+						self.setActiveSection(newIndex, self.options.animateDuration, direct, false);
 						self.dragging = false;
 					}
 				},

--- a/src/js/core/widget/core/Tabs.js
+++ b/src/js/core/widget/core/Tabs.js
@@ -258,7 +258,7 @@
 					self._changed = false;
 				} else if (self._lastIndex !== index) {
 					self._changed = true;
-					sectionChanger.setActiveSection(index, self.options.changeDuration);
+					sectionChanger.setActiveSection(index, self.options.changeDuration, false, false);
 				}
 				self._lastIndex = index;
 			};


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/659
[Problem] When calling setActiveSection API directly in app, in case of swipe strange animation occurs
[Reason] Normally _repositionSections method is called when widget is initialized.
When ui-section-active not set all values will be initialized with default ones.
When developers calls setActiveSection directly method _repositionSections is not called

[Solution] Call _repositionSections inside setActiveSection

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>