### PR TITLE
Appbar (Mobile): restore back button

### DIFF
--- a/examples/mobile/UIComponents/components/appbar/index.html
+++ b/examples/mobile/UIComponents/components/appbar/index.html
@@ -28,12 +28,12 @@
 						Title (Multiline)
 					</a>
 				</li>
-				<!-- Those examples need to updated according to current guide.
 				<li class="ui-li-anchor">
-					<a href="header/simpleTitleBack.html">
-						Simple title with back
+					<a href="navigateUpButton.html">
+						Navigate up button
 					</a>
 				</li>
+				<!-- Those examples need to updated according to current guide.
 				<li class="ui-li-anchor">
 					<a href="header/multilineTitleBack.html">
 						Multiline with back

--- a/examples/mobile/UIComponents/components/appbar/navigateUpButton.html
+++ b/examples/mobile/UIComponents/components/appbar/navigateUpButton.html
@@ -13,10 +13,10 @@
 	<div class="ui-page" id="simpleTitleBack">
 		<header>
 			<div class="ui-appbar-left-icons-container">
-				<button class="ui-btn ui-btn-icon ui-btn-icon-back" data-rel="back"></button>
+				<button class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></button>
 			</div>
 			<div class="ui-appbar-title-container">
-				<span class="ui-appbar-title">Application title</span>
+				<span class="ui-appbar-title">Sample title</span>
 			</div>
 		</header>
 		<div class="ui-content">

--- a/src/css/profile/mobile/common/appbar.less
+++ b/src/css/profile/mobile/common/appbar.less
@@ -34,7 +34,7 @@
 		&.ui-btn-icon {
 			background-color: transparent;
 			position: relative;
-			top: 14 * @px_base;
+			top: 15 * @px_base;
 
 			width: 24 * @px_base;
 			height: 24 * @px_base;
@@ -52,22 +52,35 @@
 				height: 24 * @px_base;
 			}
 
-			// TODO: icon definitions should be moved to button stylesheet (temporary solution)
-
 			&-back::after {
-				mask-image: url("images/oneui/tw_ic_ab_back_mtrl.svg");
+				mask-image: url("images/1_App_Bar/tw_ic_ab_back_mtrl.svg");
 			}
 
 			&-more::after {
-				mask-image: url("images/oneui/tw_ic_ab_more_mtrl.svg");
+				mask-image: url("images/1_App_Bar/tw_ic_ab_more_mtrl.svg");
 			}
 
 			&-search::after {
-				mask-image: url("images/oneui/tw_ic_ab_search_mtrl.svg");
+				mask-image: url("images/1_App_Bar/tw_ic_ab_search_mtrl.svg");
 			}
 
 			&-add::after {
-				mask-image: url("images/oneui/tw_ic_ab_add_mtrl.svg");
+				mask-image: url("images/1_App_Bar/tw_ic_ab_add_mtrl.svg");
+			}
+
+			// Override styles from .ui-btn-flat with icon
+			&.ui-btn-flat {
+				min-height: 24 * @px_base;
+				&::after {
+					mask-size: 100%;
+					width: 24 * @px_base;
+					height: 24 * @px_base;
+				}
+				&::before {
+					background-color: transparent;
+					width: 48 * @px_base;
+					height: 48 * @px_base;
+				}
 			}
 		}
 	}

--- a/src/css/profile/mobile/theme-changeable/images/oneui/tw_ic_ab_add_mtrl.svg
+++ b/src/css/profile/mobile/theme-changeable/images/oneui/tw_ic_ab_add_mtrl.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 53.1 (72631) - https://sketchapp.com -->
-    <title>Mobile/Dark_theme/ICON/01_ACTION_BAR/Title_Add</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Mobile/Dark_theme/ICON/01_ACTION_BAR/Title_Add" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="Fill-1" fill="#FAFAFA" points="10.875 3.25 10.875 10.875 3.25 10.875 3.25 13.125 10.875 13.125 10.875 20.75 13.125 20.75 13.125 13.125 20.75 13.125 20.75 10.875 13.125 10.875 13.125 3.25"></polygon>
-    </g>
-</svg>

--- a/src/css/profile/mobile/theme-changeable/images/oneui/tw_ic_ab_back_mtrl.svg
+++ b/src/css/profile/mobile/theme-changeable/images/oneui/tw_ic_ab_back_mtrl.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 53.1 (72631) - https://sketchapp.com -->
-    <title>Mobile/Dark_theme/ICON/01_ACTION_BAR/Title_Back</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Mobile/Dark_theme/ICON/01_ACTION_BAR/Title_Back" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="Fill-1" fill="#FAFAFA" points="14.668124 3 5 12.0003749 14.668124 21 16 19.6529932 7.78043673 12.0003749 16 4.34650688"></polygon>
-    </g>
-</svg>

--- a/src/css/profile/mobile/theme-changeable/images/oneui/tw_ic_ab_more_mtrl.svg
+++ b/src/css/profile/mobile/theme-changeable/images/oneui/tw_ic_ab_more_mtrl.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 53.1 (72631) - https://sketchapp.com -->
-    <title>Mobile/Dark_theme/ICON/01_ACTION_BAR/Title_More</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Mobile/Dark_theme/ICON/01_ACTION_BAR/Title_More" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <path d="M11.9999187,4 C13.1040731,4 14.00005,4.896 14.00005,6 C14.00005,7.104 13.1040731,8 11.9999187,8 C10.8960269,8 10.00005,7.104 10.00005,6 C10.00005,4.896 10.8960269,4 11.9999187,4 Z M11.9999187,10 C13.1040731,10 14.00005,10.896 14.00005,12 C14.00005,13.104 13.1040731,14 11.9999187,14 C10.8960269,14 10.00005,13.104 10.00005,12 C10.00005,10.896 10.8960269,10 11.9999187,10 Z M11.9999187,16 C13.1040731,16 14.00005,16.896 14.00005,18 C14.00005,19.104 13.1040731,20 11.9999187,20 C10.8960269,20 10.00005,19.104 10.00005,18 C10.00005,16.896 10.8960269,16 11.9999187,16 Z" id="Combined-Shape" fill="#FAFAFA"></path>
-    </g>
-</svg>

--- a/src/css/profile/mobile/theme-changeable/images/oneui/tw_ic_ab_search_mtrl.svg
+++ b/src/css/profile/mobile/theme-changeable/images/oneui/tw_ic_ab_search_mtrl.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 53.1 (72631) - https://sketchapp.com -->
-    <title>Mobile/Dark_theme/ICON/01_ACTION_BAR/Title_Search</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Mobile/Dark_theme/ICON/01_ACTION_BAR/Title_Search" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <path d="M5,10.4996003 C5,7.46721252 7.46694605,5 10.4990674,5 C13.5322545,5 16,7.46721252 16,10.4996003 C16,13.532521 13.5322545,16 10.4990674,16 C7.46694605,16 5,13.532521 5,10.4996003 L5,10.4996003 Z M21,19.4237908 L16.6216983,15.045747 C17.5542673,13.7889072 18.1071014,12.2346256 18.1071014,10.5531637 C18.1071014,6.38820494 14.7181225,3 10.5526478,3 C6.38820494,3 3,6.38820494 3,10.5531637 C3,14.7183805 6.38820494,18.1071014 10.5526478,18.1071014 C12.2341096,18.1071014 13.7889072,17.5542673 15.0452311,16.6216983 L19.4237908,21 L21,19.4237908 Z" id="Fill-1" fill="#FAFAFA"></path>
-    </g>
-</svg>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/714
[Problem] Back button is not visible in example
[Cause] Back button width is overwritten by btn-contained style
[Solution] Add btn-contained style specific for appbar

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>