### PR TITLE
Appbar (Mobile): Change back button to link

### DIFF
--- a/examples/mobile/UIComponents/components/appbar/actionButton/actionButtonAddAndSearch.html
+++ b/examples/mobile/UIComponents/components/appbar/actionButton/actionButtonAddAndSearch.html
@@ -13,7 +13,7 @@
 	<div class="ui-page" id="simpleTitleBack">
 		<header>
 			<div class="ui-appbar-left-icons-container">
-				<button class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></button>
+				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
 			</div>
 			<div class="ui-appbar-title-container">
 				<span class="ui-appbar-title">Sample title</span>

--- a/examples/mobile/UIComponents/components/appbar/actionButton/actionButtonText.html
+++ b/examples/mobile/UIComponents/components/appbar/actionButton/actionButtonText.html
@@ -13,7 +13,7 @@
 	<div class="ui-page" id="simpleTitleBack">
 		<header>
 			<div class="ui-appbar-left-icons-container">
-				<button class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></button>
+				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
 			</div>
 			<div class="ui-appbar-title-container">
 				<span class="ui-appbar-title">Sample title</span>

--- a/examples/mobile/UIComponents/components/appbar/actionButton/actionButtonTextText.html
+++ b/examples/mobile/UIComponents/components/appbar/actionButton/actionButtonTextText.html
@@ -13,7 +13,7 @@
 	<div class="ui-page" id="simpleTitleBack">
 		<header>
 			<div class="ui-appbar-left-icons-container">
-				<button class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></button>
+				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
 			</div>
 			<div class="ui-appbar-title-container">
 				<span class="ui-appbar-title">Sample title</span>

--- a/examples/mobile/UIComponents/components/appbar/navigateUpButton.html
+++ b/examples/mobile/UIComponents/components/appbar/navigateUpButton.html
@@ -13,7 +13,7 @@
 	<div class="ui-page" id="simpleTitleBack">
 		<header>
 			<div class="ui-appbar-left-icons-container">
-				<button class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></button>
+				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
 			</div>
 			<div class="ui-appbar-title-container">
 				<span class="ui-appbar-title">Sample title</span>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/753
[Problem] User is not navigated backwards after click on back button in appbar examples.
[Solution] Replace button to link (<a></a>) since this element is tracked TAU router.

[Remarks] This change causes wrong width (8px) of ui-appbar-left-icons-container but it
	should have 32px. Only right margin (8px) of link element is taken into account.
	It looks like icon size (24x24) is not properly added.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>