### PR TITLE
Dropdown list (Mobile): restore tw_dropdown_ic_check.svg

### DIFF
--- a/src/css/profile/mobile/theme-changeable/images/13_View_Controls/tw_dropdown_ic_check.svg
+++ b/src/css/profile/mobile/theme-changeable/images/13_View_Controls/tw_dropdown_ic_check.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+        width="60px" height="60px" viewBox="0 0 60 60" enable-background="new 0 0 60 60" xml:space="preserve">
+<polygon points="53.955,12.051 24.667,41.367 5.775,22.453 1.95,26.283 24.667,49.028 57.78,15.879 "/>
+</svg>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/780
[Problem] There is no tw_dropdown_ic_check.svg in current assets
	but the latest guide still refers to it.
[Solution] Restore tw_dropdown_ic_check.svg since it was removed by https://github.com/Samsung/TAU/pull/777

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>