### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Samsung/tau


### PR DESCRIPTION
[Issue] N/A
[Problem] TAU members are not added automatically for review
[Solution] Define @Samsung/tau members as responsible for code in repository.
They will be automatically added for review.
[Remarks] See more in [1]

[1] https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>