### PR TITLE
Appbar: fix for width of back button in appbar

### DIFF
--- a/src/css/profile/mobile/common/appbar.less
+++ b/src/css/profile/mobile/common/appbar.less
@@ -81,6 +81,7 @@
 			// Override styles from .ui-btn-flat with icon
 			&.ui-btn-flat {
 				min-height: 24 * @px_base;
+				display: block;
 				&::after {
 					mask-size: 100%;
 					width: 24 * @px_base;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/764
[Problem] Wrong width of ui-appbar-left-icons-container
[Solution]
 - Back button in icon container has not width because of
  display property

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>