### PR TITLE
Reduce border width to fix the margin issue

### DIFF
--- a/src/css/profile/mobile/common/core.less
+++ b/src/css/profile/mobile/common/core.less
@@ -151,8 +151,8 @@
 		mask-border: url(images/0_Round_corner/round.svg) 77;
 		mask-border-width: 26 * @px_base;
 		border-radius: 26 * @px_base;
-		border: 1 * @px_base solid var(--content-area-line-color);
 		box-sizing: border-box;
+		box-shadow: 0 0 0 1 * @px_base var(--content-area-line-color) inset;
 	}
 
 	.ui-content-subheader {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/825
[Problem] ui-content-area has border width with 1px. It can affect other components.
[Solution] Use the outline instead of the border.

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>