### PR TITLE
AppBar: Fix for height of text button on bottom bar

### DIFF
--- a/src/css/profile/mobile/common/bottombar.less
+++ b/src/css/profile/mobile/common/bottombar.less
@@ -11,6 +11,7 @@
         .ui-btn {
             font-size: 18 * @sp_base;
             max-width: 100%;
+            height: 56 * @px_base;
         }
     }
 }


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/769
[Problem] Button on bottom bar has wrong height
[Solution]
 - Height of button has been changed

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>