### PR TITLE
[mobile] Ripple effect for master on/off switch

### DIFF
--- a/src/css/profile/mobile/common/masteronoffswitch.less
+++ b/src/css/profile/mobile/common/masteronoffswitch.less
@@ -21,12 +21,43 @@
         display: flex;
         align-items: center;
 
+        &::before {
+            content: "";
+            width: 100%;
+            height: 64 * @px_base;
+            opacity: 0;
+            position: absolute;
+            left: 0;
+            top: 0;
+            border-radius: 26 * @px_base;
+            background-color: var(--ripple-color);
+        }
+
+        &-active {
+            &::before {
+                opacity: 1;
+            }
+        }
+
         span {
             flex: 1;
         }
-        &-active {
+
+        &-on {
             color: var(--color-white);
             background-color: var(--master-on-off-on-color);
+        }
+    }
+}
+
+// turn off ripple effect for the master switch input
+// it already has an effect for the whole switch
+.ui-master-on-off-switch .ui-on-off-switch-input {
+    &:active {
+        & ~ .ui-on-off-switch-button {
+            &::before {
+                opacity: 0;
+            }
         }
     }
 }

--- a/src/js/core/widget/core/MasterOnOffSwitch.js
+++ b/src/js/core/widget/core/MasterOnOffSwitch.js
@@ -163,13 +163,21 @@
 					labelText = self._ui.labelTextOnOff;
 
 				if (onOff.checked) {
-					label.classList.add("ui-on-off-label-active");
+					label.classList.add("ui-on-off-label-on");
 					labelText.innerHTML = "On";
 				} else {
-					label.classList.remove("ui-on-off-label-active");
+					label.classList.remove("ui-on-off-label-on");
 					labelText.innerHTML = "Off";
 				}
 				self._disableAllOnOff(!onOff.checked);
+			}
+
+			function onTouchStart(self) {
+				self._ui.labelOnOff.classList.add("ui-on-off-label-active");
+			}
+
+			function onTouchEnd(self) {
+				self._ui.labelOnOff.classList.remove("ui-on-off-label-active");
 			}
 
 			/**
@@ -182,9 +190,15 @@
 			prototype._bindEvents = function () {
 				var self = this,
 					onOff = self._ui.onOff,
-					_onChangeMasterOnOff = onChangeMasterOnOff.bind(null, self);
+					labelOnOff = self._ui.labelOnOff,
+					_onChangeMasterOnOff = onChangeMasterOnOff.bind(null, self),
+					_onTouchStart = onTouchStart.bind(null, self),
+					_onTouchEnd = onTouchEnd.bind(null, self);
+
 
 				onOff.addEventListener("change", _onChangeMasterOnOff);
+				labelOnOff.addEventListener("vmousedown", _onTouchStart);
+				labelOnOff.addEventListener("vmouseup", _onTouchEnd);
 
 				self._onChangeMasterOnOff = _onChangeMasterOnOff;
 			};
@@ -194,8 +208,12 @@
 					onOff = self._ui.onOff;
 
 				onOff.removeEventListener("change", self._onChangeMasterOnOff);
+				onOff.removeEventListener("vmousedown", self._onTouchStart);
+				onOff.removeEventListener("vmouseup", self._onTouchEnd);
 
 				self._onChangeMasterOnOff = null;
+				self._onTouchStart = null;
+				self._onTouchEnd = null;
 			};
 
 			/**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/795
[Problem] No ripple effect for master on/off switch
[Solution] Add active class to suport touch event.
Add ripple effect for master switch.
Remove ripple effect for input switch which is in master switch.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>