### PR TITLE
[mobile] Add ripple effect for radio button

### DIFF
--- a/src/css/profile/mobile/common/radio.less
+++ b/src/css/profile/mobile/common/radio.less
@@ -7,40 +7,37 @@ input[type="radio"].ui-radio {
 	-webkit-appearance: none;
 	margin: 0 18 * @px_base;
 
-	&::before,
+	&::before {
+		content: "";
+		position: absolute;
+		left: 0;
+		top: 0;
+		width: 32 * @px_base;
+		height: 32 * @px_base;
+		background-color: var(--ripple-color);
+		border-radius: 100%;
+		opacity: 0;
+	}
+
 	&::after {
 		content: "";
 		position: absolute;
-		width: 100%;
-	}
-
-	&::before {
 		height: 100%;
-		opacity: 0.8;
-		background-color: var(--control-inactive-color);
-		mask-image: url("images/3_Controllers/Radio/sem_btn_radio_to_on_mtrl_000.svg"); 
-		mask-size: 100%, 0;
+		width: 100%;
+		bottom: 0;
+		background-color: var(--control-active-color);
+		mask-image: url("images/3_Controllers/Radio/sem_btn_radio_to_on_mtrl_000.svg");
+		mask-size: 100%;
 		mask-position: center;
 		mask-repeat: no-repeat;
 	}
 
-	&::after {
-		height: 0;
-		bottom: 0;
-		width: 100%;
-		box-sizing: content-box;
-		background-color: var(--control-active-color);
-		mask-image: url("images/3_Controllers/Radio/sem_btn_radio_to_on_mtrl_026.svg");
-		mask-size: 100%;
-		mask-position: center;
-	}
-
-	&:checked::before {
-		mask-size: 100%, 100%;
-	}
-
 	&:checked::after {
-		height: 100%;
+		mask-image: url("images/3_Controllers/Radio/sem_btn_radio_to_on_mtrl_026.svg");
+	}
+
+	&:active::before {
+		opacity: 1;
 	}
 
 	&:disabled {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/768
[Problem] No ripple effect for button
[Solution] Use "before" pseudo-class to show press ripple effect.
Move bitmap masks to "after" pseudo-class.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>