### PR TITLE
DropDownMenu: added ripple effect to option items

### DIFF
--- a/src/css/profile/mobile/common/dropdownmenu.less
+++ b/src/css/profile/mobile/common/dropdownmenu.less
@@ -260,9 +260,23 @@
 			overflow: hidden;
 			text-overflow: ellipsis;
 			color: var(--dropdown-menu-options-color);
-			&:focus,
-			&:active {
+
+			&:focus, &:active {
 				outline: none;
+			}
+
+			&::before {
+				content: "";
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				background-color: var(--ripple-color);
+				opacity: 0;
+			}
+			&:active::before {
+				opacity: 1;
 			}
 		}
 	}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/832
[Problem] DropDown list - lack of ripple effect for options
[Solution]
 Ripple effect has been added

![image](https://user-images.githubusercontent.com/29534410/77744386-dd72c100-7019-11ea-9b64-13fcee290259.png)

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>