### PR TITLE
Dropdown list (Mobile): two lines

### DIFF
--- a/examples/mobile/UIComponents/components/appbar/index.html
+++ b/examples/mobile/UIComponents/components/appbar/index.html
@@ -34,6 +34,11 @@
 					</a>
 				</li>
 				<li class="ui-li-anchor">
+					<a href="more-option-list-max-width.html">
+						More option list (Max width)
+					</a>
+				</li>
+				<li class="ui-li-anchor">
 					<a href="action-button.html">
 						Action button
 					</a>

--- a/examples/mobile/UIComponents/components/appbar/more-option-list-max-width.html
+++ b/examples/mobile/UIComponents/components/appbar/more-option-list-max-width.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta content="width=device-width, user-scalable=no" name="viewport" />
+	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../css/style.css" rel="stylesheet" />
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js"></script>
+</head>
+
+<body>
+	<div class="ui-page">
+		<header>
+			<div class="ui-appbar-left-icons-container">
+				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
+			</div>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat" onClick="openDropdownMenu()"></button>
+				<select data-native-menu="false" id="dropdownmenu" style="display: none">
+					<option value="1">
+						Option1
+					</option>
+					<option value="2" class="ui-dropdown-two-lines">
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam consectetur venenatis blandit. Praesent vehicula, libero non pretium vulputate, lacus arcu facilisis lectus, sed feugiat tellus nulla eu dolor. Nulla porta bibendum lectus quis euismod. Aliquam volutpat ultricies porttitor. Cras risus nisi, accumsan vel cursus ut, sollicitudin vitae dolor. Fusce scelerisque eleifend lectus in bibendum. Suspendisse lacinia egestas felis a volutpat.
+					</option>
+					<option value="3">
+						Option3
+					</option>
+					<option value="4">
+						Option4
+					</option>
+				</select>
+			</div>
+		</header>
+
+		<div class="ui-content">
+		</div>
+
+		<script>
+			function openDropdownMenu() {
+				var dropdownmenuWidget = tau.widget.DropdownMenu(document.getElementById("dropdownmenu"));
+
+				dropdownmenuWidget.open();
+			}
+		</script>
+
+	</div> <!-- /page -->
+
+</body>
+
+</html>

--- a/src/css/profile/mobile/common/dropdownmenu.less
+++ b/src/css/profile/mobile/common/dropdownmenu.less
@@ -256,11 +256,18 @@
 			.font(regular);
 			display: block;
 			position: relative;
-			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			color: var(--dropdown-menu-options-color);
-
+			&.ui-dropdown-two-lines {
+				max-height: 2em;	// FIXME: max-height should be 2 * line-height but gives more than two lines.
+				line-height: 1.4em;
+				// FIXME: add support for text ellipsis for second line manually since
+				//		  -webkit-line-clamp does not work on Tizen Emulator 5.5.
+			}
+			&:not(.ui-dropdown-two-lines) {
+				white-space: nowrap;
+			}
 			&:focus, &:active {
 				outline: none;
 			}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/836
[Problem] No support and example for option displayed in
	two lines.
[Solution] Add example and separate class.
[Remarks] This should be implemented using -webkit-line-clamp
	but this does not work on Tizen Emulator 5.5.
	TODO: add support for text ellipsis for second line manually.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>