### PR TITLE
Dropdown list (Mobile): show list without selection

### DIFF
--- a/examples/mobile/UIComponents/components/appbar/more-option-list-max-width.html
+++ b/examples/mobile/UIComponents/components/appbar/more-option-list-max-width.html
@@ -14,6 +14,9 @@
 			<div class="ui-appbar-left-icons-container">
 				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
 			</div>
+			<div class="ui-appbar-title-container">
+				<span class="ui-appbar-title">More option list (Max width)</span>
+			</div>
 			<div class="ui-appbar-action-buttons-container">
 				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat" onClick="openDropdownMenu()"></button>
 				<select data-native-menu="false" id="dropdownmenu" style="display: none">
@@ -37,8 +40,11 @@
 		</div>
 
 		<script>
+			var dropDownMenu = document.getElementById("dropdownmenu");
+			dropdownmenu.selectedIndex = -1;
+
 			function openDropdownMenu() {
-				var dropdownmenuWidget = tau.widget.DropdownMenu(document.getElementById("dropdownmenu"));
+				var dropdownmenuWidget = tau.widget.DropdownMenu(dropDownMenu);
 
 				dropdownmenuWidget.open();
 			}

--- a/src/js/profile/mobile/widget/DropdownMenu.js
+++ b/src/js/profile/mobile/widget/DropdownMenu.js
@@ -1025,8 +1025,6 @@
 					listItemWidthOffsets = [].slice.call(ui.elOptionContainer.children).map(mapItemWidth),
 					biggestListItemWidth = Math.max.apply(Math, listItemWidthOffsets),
 					wrapperMinWidth = parseInt(window.getComputedStyle(ui.elOptionWrapper).minWidth, 10),
-					selectedItem = ui.elOptionContainer.querySelector("." + classes.selected),
-					stylesOfSelectedOptionAfter = window.getComputedStyle(selectedItem, ":after"),
 					options = self.options,
 					scrollTop = ui.elOptionWrapper.parentNode.querySelector(".ui-scrollview-clip").scrollTop,
 					height,
@@ -1038,10 +1036,7 @@
 				self._offsetTop = getTopOffsetOfElement(ui.elSelectWrapper, ui.page);
 				areaInfo = self._chooseDirection();
 
-				width = biggestListItemWidth > wrapperMinWidth ?
-				biggestListItemWidth + parseInt(stylesOfSelectedOptionAfter.marginRight, 10) +
-				parseInt(stylesOfSelectedOptionAfter.width, 10) : wrapperMinWidth;
-
+				width = Math.max(biggestListItemWidth, wrapperMinWidth);
 				height = optionHeight;
 
 				// This part decides the location and direction of option list.
@@ -1261,7 +1256,9 @@
 						return;
 					}
 					eventUtils.trigger(ui.elSelect, "change");
-					previousOption.classList.remove(classes.selected);
+					if (previousOption) {
+						previousOption.classList.remove(classes.selected);
+					}
 					selectedOption.classList.add(classes.selected);
 				}
 			};


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/841
[Problem] Dropdow example for Appbar does not have selected item
[Solution] update the example to show list without selection and
	fix TAU code by not assuming that we alywas have selected item.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>