### PR TITLE
Spin: Add a new option to select the drag target element

### DIFF
--- a/src/js/core/widget/core/Spin.js
+++ b/src/js/core/widget/core/Spin.js
@@ -83,7 +83,7 @@
 				 * @property {string} [options.labels=""] defines labels for values likes days of week separated by ","
 				 * // eg. "Monday,Tuesday,Wednesday"
 				 * @property {string} [options.digits=0] value filling with zeros, eg. 002 for digits=3;
-				 * // eg. "Monday,Tuesday,Wednesday"
+				 * @property {string} [options.dragTarget="document"] set target element for drag gesture
 				 * @member ns.widget.core.Spin
 				 */
 				this.options = {
@@ -102,7 +102,8 @@
 					loop: "enabled",
 					labels: [],
 					digits: 0, // 0 - doesn't complete by zeros
-					value: 0
+					value: 0,
+					dragTarget: "document" // "document" | "self"
 				};
 				this._ui = {};
 				this.length = this.options.max - this.options.min + 1;
@@ -388,6 +389,7 @@
 			options.labels = (Array.isArray(options.labels)) ? options.labels : options.labels.split(",");
 
 			self.length = options.max - options.min + 1;
+			self.dragTarget = (options.dragTarget === "document") ? document : self.element;
 
 			self._refresh();
 		};
@@ -488,7 +490,7 @@
 					element.classList.remove(classes.ENABLING);
 				}, ENABLING_DURATION);
 				element.classList.add(classes.ENABLED);
-				utilsEvents.on(document, "drag dragend", self);
+				utilsEvents.on(self.dragTarget, "drag dragend", self);
 
 			} else {
 				element.classList.add(classes.ENABLING);
@@ -497,7 +499,7 @@
 					self.refresh();
 				}, ENABLING_DURATION);
 				element.classList.remove(classes.ENABLED);
-				utilsEvents.off(document, "drag dragend", self);
+				utilsEvents.off(self.dragTarget, "drag dragend", self);
 				// disable animation
 				self._animation.stop();
 			}
@@ -517,7 +519,7 @@
 
 			// if element is detached from DOM then event listener should be removed
 			if (document.getElementById(self.element.id) === null) {
-				utilsEvents.off(document, "drag dragend", self);
+				utilsEvents.off(self.dragTarget, "drag dragend", self);
 			} else {
 				if (self.options.enabled) {
 					value = self.value();
@@ -578,7 +580,7 @@
 			var self = this;
 
 			// enabled drag gesture for document
-			utilsEvents.enableGesture(document, new gesture.Drag({
+			utilsEvents.enableGesture(self.dragTarget, new gesture.Drag({
 				blockHorizontal: true
 			}));
 
@@ -588,9 +590,9 @@
 		prototype._unbindEvents = function () {
 			var self = this;
 
-			utilsEvents.disableGesture(document);
+			utilsEvents.disableGesture(self.dragTarget);
 
-			utilsEvents.off(document, "drag dragend", self);
+			utilsEvents.off(self.dragTarget, "drag dragend", self);
 			utilsEvents.off(self.element, "click", self);
 		};
 

--- a/tests/js/core/widget/core/Spin/Spin.js
+++ b/tests/js/core/widget/core/Spin/Spin.js
@@ -16,7 +16,7 @@
 		}
 	});
 
-	test("Default options Spin test", 16, function () {
+	test("Default options Spin test", 17, function () {
 		var spin = document.getElementById("spin"),
 			spinWidget = tau.engine.instanceWidget(spin, "Spin"),
 			spinClasses = {
@@ -37,7 +37,8 @@
 				moveFactor: 0.4,
 				loop: "enabled",
 				labels: [],
-				digits: 0 // 0 - doesn't complete by zeros
+				digits: 0, // 0 - doesn't complete by zeros,
+				dragTarget: "document"
 			};
 
 		ok(spin.classList.contains(spinClasses.spin),
@@ -67,17 +68,19 @@
 			"Default option loop of Spin is " + defaultoptions.loop);
 		equal(spinWidget.option("digits"), defaultoptions.digits,
 			"Default option digits of Spin is " + defaultoptions.digits);
+		equal(typeof spinWidget.option("dragTarget"), typeof defaultoptions.dragTarget,
+			"Default option dragTarget of Spin is " + typeof defaultoptions.dragTarget);
 		spinWidget.value(5);
 		equal(spinWidget.value(), 5,
 			"Default option value of Spin is " + 5);
 		equal(typeof spinWidget.option("labels"), typeof defaultoptions.labels,
-			"TYpe of Default option labels of Spin is " + typeof defaultoptions.labels);
+			"Type of Default option labels of Spin is " + typeof defaultoptions.labels);
 
 		spinWidget.destroy();
 
 	});
 
-	test("Defined options Spin test", 13, function () {
+	test("Defined options Spin test", 14, function () {
 		var spin = document.getElementById("spin"),
 			options = {
 				min: 3,
@@ -93,7 +96,8 @@
 				moveFactor: 0.1,
 				loop: "disabled",
 				labels: ["Aaa", "Bbb", "Ccc", "Ddd"],
-				digits: 3 // 0 - doesn't complete by zeros
+				digits: 3, // 0 - doesn't complete by zeros
+				dragTarget: "self"
 			},
 			spinWidget = tau.engine.instanceWidget(spin, "Spin", options);
 
@@ -121,6 +125,8 @@
 			"Option labels of Spin is " + options.labels);
 		equal(spinWidget.option("digits"), options.digits,
 			"Option digits of Spin is " + options.digits);
+		equal(spinWidget.option("dragTarget"), options.dragTarget,
+			"Option dragTarget of Spin is " + options.dragTarget);
 
 		spinWidget.destroy();
 

--- a/tests/js/profile/mobile/widget/Spin/Spin.js
+++ b/tests/js/profile/mobile/widget/Spin/Spin.js
@@ -16,7 +16,7 @@
 		}
 	});
 
-	test("Default options Spin test", 16, function () {
+	test("Default options Spin test", 17, function () {
 		var spin = document.getElementById("spin"),
 			spinWidget = tau.engine.instanceWidget(spin, "Spin"),
 			spinClasses = {
@@ -37,7 +37,8 @@
 				moveFactor: 0.4,
 				loop: "enabled",
 				labels: [],
-				digits: 0 // 0 - doesn't complete by zeros
+				digits: 0, // 0 - doesn't complete by zeros
+				dragTarget: "document"
 			};
 
 		ok(spin.classList.contains(spinClasses.spin),
@@ -67,6 +68,8 @@
 			"Default option loop of Spin is " + defaultoptions.loop);
 		equal(spinWidget.option("digits"), defaultoptions.digits,
 			"Default option digits of Spin is " + defaultoptions.digits);
+		equal(spinWidget.option("dragTarget"), defaultoptions.dragTarget,
+			"Default option dragTarget of Spin is " + defaultoptions.dragTarget);
 		spinWidget.value(5);
 		equal(spinWidget.value(), 5,
 			"Default option value of Spin is " + 5);
@@ -77,7 +80,7 @@
 
 	});
 
-	test("Defined options Spin test", 13, function () {
+	test("Defined options Spin test", 14, function () {
 		var spin = document.getElementById("spin"),
 			options = {
 				min: 3,
@@ -93,7 +96,8 @@
 				moveFactor: 0.1,
 				loop: "disabled",
 				labels: ["Aaa", "Bbb", "Ccc", "Ddd"],
-				digits: 3 // 0 - doesn't complete by zeros
+				digits: 3, // 0 - doesn't complete by zeros
+				dragTarget: "self"
 			},
 			spinWidget = tau.engine.instanceWidget(spin, "Spin", options);
 
@@ -121,6 +125,8 @@
 			"Option labels of Spin is " + options.labels);
 		equal(spinWidget.option("digits"), options.digits,
 			"Option digits of Spin is " + options.digits);
+		equal(spinWidget.option("dragTarget"), options.dragTarget,
+			"Option dragTarget of Spin is " + options.dragTarget);
 
 		spinWidget.destroy();
 

--- a/tests/js/profile/wearable/widget/wearable/Spin/spin.js
+++ b/tests/js/profile/wearable/widget/wearable/Spin/spin.js
@@ -9,7 +9,7 @@ module("Spin tests (circular)", {
 	}
 });
 
-test("Default options Spin test", 16, function () {
+test("Default options Spin test", 17, function () {
 	var spin = document.getElementById("spin"),
 		spinWidget = new tau.widget.Spin(spin),
 		spinClasses = {
@@ -30,7 +30,8 @@ test("Default options Spin test", 16, function () {
 			moveFactor: 0.4,
 			loop: "enabled",
 			labels: [],
-			digits: 0 // 0 - doesn't complete by zeros
+			digits: 0, // 0 - doesn't complete by zeros
+			dragTarget: "document"
 		};
 
 	ok(spin.classList.contains(spinClasses.spin),
@@ -60,6 +61,8 @@ test("Default options Spin test", 16, function () {
 		"Default option loop of Spin is " + defaultoptions.loop);
 	equal(spinWidget.option("digits"), defaultoptions.digits,
 		"Default option digits of Spin is " + defaultoptions.digits);
+	equal(spinWidget.option("dragTarget"), defaultoptions.dragTarget,
+		"Default option dragTarget of Spin is " + defaultoptions.dragTarget);
 	spinWidget.value(5);
 	equal(spinWidget.value(), 5,
 		"Default option value of Spin is " + 5);
@@ -70,7 +73,7 @@ test("Default options Spin test", 16, function () {
 
 });
 
-test("Defined options Spin test", 13, function () {
+test("Defined options Spin test", 14, function () {
 	var spin = document.getElementById("spin"),
 		options = {
 			min: 3,
@@ -86,7 +89,8 @@ test("Defined options Spin test", 13, function () {
 			moveFactor: 0.1,
 			loop: "disabled",
 			labels: ["Aaa", "Bbb", "Ccc", "Ddd"],
-			digits: 3 // 0 - doesn't complete by zeros
+			digits: 3, // 0 - doesn't complete by zeros
+			dragTarget: "self"
 		},
 		spinWidget = new tau.widget.Spin(spin, options);
 
@@ -114,6 +118,8 @@ test("Defined options Spin test", 13, function () {
 		"Option labels of Spin is " + options.labels);
 	equal(spinWidget.option("digits"), options.digits,
 		"Option digits of Spin is " + options.digits);
+	equal(spinWidget.option("dragTarget"), options.dragTarget,
+		"Option dragTarget of Spin is " + options.dragTarget);
 
 	spinWidget.destroy();
 


### PR DESCRIPTION
[Issue] N/A
[Problem] Drag target is always document
[Solution] Add new option to select the target for dragging spin

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>