### PR TITLE
UIComponets (Wearable): add "main text only" example to Lists

### DIFF
--- a/examples/wearable/UIComponents/contents/presentation-views/list/list-arclistview.js
+++ b/examples/wearable/UIComponents/contents/presentation-views/list/list-arclistview.js
@@ -1,0 +1,33 @@
+/*global tau*/
+(function () {
+	"use strict";
+	var /**
+		 * Cache of arc-listview-page
+		 * @type {HTMLElement}
+		 */
+		page = document.getElementById("arc-listview-page"),
+		/**
+		 * ArcListview widget instance
+		 * @type {Object}
+		 */
+		widget = null;
+
+	/**
+	 * Create ArcListview widget and scroll to third position before page show
+	 */
+	page.addEventListener("pagebeforeshow", function () {
+		var element = page.querySelector(".ui-arc-listview");
+
+		widget = tau.widget.ArcListview(element);
+		widget.scrollToPosition(2);
+	});
+
+	/**
+	 * Destroy ArcListview widget on page hide
+	 */
+	page.addEventListener("pagehide", function () {
+		widget.destroy();
+	});
+})();
+
+

--- a/examples/wearable/UIComponents/contents/presentation-views/list/main-text-only.html
+++ b/examples/wearable/UIComponents/contents/presentation-views/list/main-text-only.html
@@ -4,7 +4,7 @@
 <head>
 	<meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport" />
 	<title>
-		List
+		Wearable UI
 	</title>
 	<link href="../../../lib/tau/wearable/theme/default/tau.css" rel="stylesheet" />
 	<link href="../../../lib/tau/wearable/theme/default/tau.circle.css" rel="stylesheet" />
@@ -15,26 +15,42 @@
 </head>
 
 <body>
-	<div class="ui-page" data-go-to-top-button="true">
-		<header>
+	<div class="ui-page" id="arc-listview-page">
+		<header class="ui-header">
 			<h2 class="ui-title">
-				List
+				Main Text Only
 			</h2>
 		</header>
 		<div class="ui-content">
-			<ul class="ui-listview">
+			<ul class="ui-arc-listview ui-arc-listview-5" data-visible-items="5">
 				<li>
-					<a href="basic-list.html">
-						Basic List
+					<a href="#">
+						List 01
 					</a>
 				</li>
 				<li>
-					<a href="main-text-only.html">
-						Main Text Only
+					<a href="#">
+						List 02
+					</a>
+				</li>
+				<li>
+					<a href="#">
+						List 03
+					</a>
+				</li>
+				<li>
+					<a href="#">
+						List 04
+					</a>
+				</li>
+				<li>
+					<a href="#">
+						List 05
 					</a>
 				</li>
 			</ul>
 		</div>
+		<script src="list-arclistview.js"></script>
 	</div>
 </body>
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/730
[Problem] Missing example for Lists with main text only
[Solution] use arc-listview-5 and data-visible-items set to 5

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>