### PR TITLE
Spin (mobile): Apply default options for mobile profile

### DIFF
--- a/src/css/profile/mobile/common/spin.less
+++ b/src/css/profile/mobile/common/spin.less
@@ -1,7 +1,7 @@
 .ui-spin {
 	position: relative;
 	display: inline-flex;
-	height: 120 * @px_base;
+	height: 164 * @px_base;
 	background-color: transparent;
 	overflow: hidden;
 	font-size: 32 * @sp_base;

--- a/src/js/core/widget/core/Spin.js
+++ b/src/js/core/widget/core/Spin.js
@@ -33,6 +33,7 @@
 	define([
 		"../core",
 		"../BaseWidget",
+		"../../../core/engine",
 		"../../../core/util/animation/animation",
 		"../../../core/event/gesture"
 	],
@@ -40,6 +41,7 @@
 		//>>excludeEnd("tauBuildExclude");
 		var document = window.document,
 			BaseWidget = ns.widget.BaseWidget,
+			engine = ns.engine,
 			utilsEvents = ns.event,
 			gesture = utilsEvents.gesture,
 
@@ -619,6 +621,14 @@
 
 		Spin.prototype = prototype;
 		ns.widget.core.Spin = Spin;
+
+		engine.defineWidget(
+			"Spin",
+			".ui-spin",
+			[],
+			Spin,
+			"core"
+		);
 
 		//>>excludeStart("tauBuildExclude", pragmas.tauBuildExclude);
 		return Spin;

--- a/src/js/profile/mobile/widget/Spin.js
+++ b/src/js/profile/mobile/widget/Spin.js
@@ -32,67 +32,43 @@
 		"../../../core/widget/core/Spin",
 		"../../../core/engine",
 		"../../../core/util/object",
-		"../../../core/util/selectors"
 	],
 	function () {
 		//>>excludeEnd("tauBuildExclude");
 		var CoreSpin = ns.widget.core.Spin,
 			CoreSpinPrototype = CoreSpin.prototype,
 			engine = ns.engine,
-			selectors = ns.util.selectors,
-			utilsEvents = ns.event,
 			objectUtil = ns.util.object,
 			classes = objectUtil.copy(CoreSpin.classes),
 			Spin = function () {
-				var self = this;
+				var self = this,
+					options = {
+						scaleFactor: 0,
+						moveFactor: 0.5,
+						dragTarget: "self"
+					};
 
 				CoreSpin.call(self);
+
+				// Merge options from prototype
+				self.options = (!self.options) ?
+					options :
+					objectUtil.fastMerge(self.options, options);
 			},
 			prototype = new CoreSpin();
+
+		prototype._init = function () {
+			var self = this;
+
+			CoreSpinPrototype._init.call(self);
+
+			// Enable the spin by default
+			self.option("enabled", true);
+		}
 
 		Spin.prototype = prototype;
 		Spin.classes = classes,
 		Spin.timing = CoreSpin.timing;
-
-		prototype._vclick = function (event) {
-			var target = event.target;
-
-			if (selectors.getClosestBySelector(target, "." + classes.SPIN) === null) {
-				this.option("enabled", false);
-			} else {
-				if (!this.option("enabled")) {
-					this.option("enabled", true);
-				} else if (target.classList.contains(classes.SELECTED)) {
-					this.option("enabled", false);
-				}
-			}
-		}
-
-		prototype.handleEvent = function (event) {
-			var self = this;
-
-			CoreSpinPrototype.handleEvent.call(self, event);
-
-			if (event.type === "vclick") {
-				self._vclick(event);
-			}
-		}
-
-		prototype._bindEvents = function () {
-			var self = this;
-
-			CoreSpinPrototype._bindEvents.call(self);
-
-			utilsEvents.on(document, "vclick", self);
-		}
-
-		prototype._unbindEvents = function () {
-			var self = this;
-
-			CoreSpinPrototype._unbindEvents.call(self);
-
-			utilsEvents.off(document, "vclick", self);
-		}
 
 		ns.widget.mobile.Spin = Spin;
 
@@ -101,7 +77,8 @@
 			".ui-spin",
 			[],
 			Spin,
-			"mobile"
+			"mobile",
+			true
 		);
 
 		//>>excludeStart("tauBuildExclude", pragmas.tauBuildExclude);

--- a/tests/js/core/widget/core/Spin/Spin.js
+++ b/tests/js/core/widget/core/Spin/Spin.js
@@ -18,7 +18,7 @@
 
 	test("Default options Spin test", 17, function () {
 		var spin = document.getElementById("spin"),
-			spinWidget = tau.engine.instanceWidget(spin, "Spin"),
+			spinWidget = tau.engine.instanceWidget(spin, "core.Spin"),
 			spinClasses = {
 				spin: "ui-spin",
 				sample: "sample-spin"
@@ -99,7 +99,7 @@
 				digits: 3, // 0 - doesn't complete by zeros
 				dragTarget: "self"
 			},
-			spinWidget = tau.engine.instanceWidget(spin, "Spin", options);
+			spinWidget = tau.engine.instanceWidget(spin, "core.Spin", options);
 
 		equal(spinWidget.option("min"), options.min, "Option min of Spin is " + options.min);
 		equal(spinWidget.option("max"), options.max, "Option max of Spin is " + options.max);
@@ -139,7 +139,7 @@
 				max: undefined,
 				duration: undefined
 			},
-			spinWidget = tau.engine.instanceWidget(spin, "Spin", options);
+			spinWidget = tau.engine.instanceWidget(spin, "core.Spin", options);
 
 		spinWidget.value(undefined);
 
@@ -162,7 +162,7 @@
 				loop: "disabled"
 			},
 			testValues = [0, 10, 100, 11],
-			spinWidget = tau.engine.instanceWidget(spin, "Spin", options);
+			spinWidget = tau.engine.instanceWidget(spin, "core.Spin", options);
 
 		spinWidget.value(testValues[0]);
 		equal(spinWidget.value(), testValues[0], "Spin value check (0)");

--- a/tests/js/profile/mobile/widget/Spin/Spin.js
+++ b/tests/js/profile/mobile/widget/Spin/Spin.js
@@ -18,7 +18,7 @@
 
 	test("Default options Spin test", 17, function () {
 		var spin = document.getElementById("spin"),
-			spinWidget = tau.engine.instanceWidget(spin, "Spin"),
+			spinWidget = tau.engine.instanceWidget(spin, "mobile.Spin"),
 			spinClasses = {
 				spin: "ui-spin",
 				sample: "sample-spin"
@@ -33,12 +33,12 @@
 				rollHeight: "custom", // "container" | "item" | "custom"
 				itemHeight: 38,
 				momentumLevel: 0, // 0 - one item on swipe
-				scaleFactor: 0.4,
-				moveFactor: 0.4,
+				scaleFactor: 0,
+				moveFactor: 0.5,
 				loop: "enabled",
 				labels: [],
 				digits: 0, // 0 - doesn't complete by zeros
-				dragTarget: "document"
+				dragTarget: "self"
 			};
 
 		ok(spin.classList.contains(spinClasses.spin),
@@ -99,7 +99,7 @@
 				digits: 3, // 0 - doesn't complete by zeros
 				dragTarget: "self"
 			},
-			spinWidget = tau.engine.instanceWidget(spin, "Spin", options);
+			spinWidget = tau.engine.instanceWidget(spin, "mobile.Spin", options);
 
 		equal(spinWidget.option("min"), options.min, "Option min of Spin is " + options.min);
 		equal(spinWidget.option("max"), options.max, "Option max of Spin is " + options.max);


### PR DESCRIPTION
[Issue] N/A
[Problem] Need to apply different options for each profile
[Solution]
1. Add a new options variable to apply options for mobile profile
2. Delete vclick event handlers and enable the spin by default
3. Modify the test values to fit with changed options

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>