### PR TITLE
Fix to calculate the height of the Spin widget

### DIFF
--- a/src/css/profile/mobile/common/timepicker.less
+++ b/src/css/profile/mobile/common/timepicker.less
@@ -24,6 +24,6 @@
 
 	.ui-spin {
 		width: 100%;
-		height: 100%;
+		height: 164 * @px_base;
 	}
 }

--- a/src/js/core/widget/core/Spin.js
+++ b/src/js/core/widget/core/Spin.js
@@ -180,7 +180,7 @@
 				options = self.options,
 				itemHeight = self._itemHeight,
 				state = self._objectValue,
-				centerY = (self._containerRect.height - itemHeight) / 2;
+				centerY = (self._containerHeight - itemHeight) / 2;
 
 			items.forEach(function (item, index) {
 				var change = transform(state.value, index, centerY, options);
@@ -337,17 +337,17 @@
 
 			// determine item height for scroll
 			if (options.rollHeight === "container") {
-				itemHeight = self._containerRect.height;
+				itemHeight = self._containerHeight;
 			} else if (options.rollHeight === "custom") {
 				itemHeight = options.itemHeight;
 			} else { // item height
 				item = items[0];
 				itemHeight = (item) ?
 					item.getBoundingClientRect().height :
-					self._containerRect.height;
+					self._containerHeight;
 			}
 			self._itemHeight = itemHeight;
-			centerY = (self._containerRect.height - itemHeight) / 2,
+			centerY = (self._containerHeight - itemHeight) / 2,
 
 			// set position;
 			items.forEach(function (item, index) {
@@ -369,7 +369,7 @@
 		prototype._refresh = function () {
 			var self = this;
 
-			self._containerRect = self.element.getBoundingClientRect();
+			self._containerHeight = parseInt(getComputedStyle(self.element).height, 10);
 			self._modifyItems();
 			self._show();
 		};

--- a/src/js/profile/mobile/widget/TimePicker.js
+++ b/src/js/profile/mobile/widget/TimePicker.js
@@ -97,6 +97,11 @@
 				self._setValue(new Date());
 
 				self.option("format", options.format);
+
+				// Calculate the spin widget after building the widget
+				Object.keys(self._spins).forEach(function (key) {
+					self._spins[key].refresh();
+				});
 			};
 
 			/**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/900
[Problem] The getBoundingClientRect() returns the '0' for the height of containerRect
[Solution] Modify the calculation for the containerHeight to get the defined height on the css style

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>