### PR TITLE
Add circullar scrollbar example

### DIFF
--- a/examples/wearable/UIComponents/contents/etc/index.html
+++ b/examples/wearable/UIComponents/contents/etc/index.html
@@ -51,11 +51,6 @@
 					</a>
 				</li>
 				<li>
-					<a href="rotaryevent/index.html">
-						Rotary Scrolling
-					</a>
-				</li>
-				<li>
 					<a href="interactive/index.html">
 						Interactive
 					</a>

--- a/examples/wearable/UIComponents/contents/navigationelements/scrollbar/circularly-vertical-bar.html
+++ b/examples/wearable/UIComponents/contents/navigationelements/scrollbar/circularly-vertical-bar.html
@@ -17,16 +17,16 @@
 </head>
 
 <body>
-	<div class="ui-page" id="pageRotaryEvent" data-go-to-top-button="true">
+	<div class="ui-page" id="pageCircularlyVerticalBar" data-go-to-top-button="true">
 		<header>
 			<h2 class="ui-title">
-				Rotary Scrolling
+				Circularly vertical bar
 			</h2>
 		</header>
 		<div class="ui-content">
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 		</div>
-		<script src="rotaryEvent.js">
+		<script src="circularly-vertical-bar.js">
 		</script>
 	</div>
 </body>

--- a/examples/wearable/UIComponents/contents/navigationelements/scrollbar/circularly-vertical-bar.js
+++ b/examples/wearable/UIComponents/contents/navigationelements/scrollbar/circularly-vertical-bar.js
@@ -3,7 +3,7 @@
 	/**
 	 * page - Rotary event page element
 	 */
-	var page = document.getElementById("pageRotaryEvent");
+	var page = document.getElementById("pageCircularlyVerticalBar");
 
 	/**
 	 * pagebeforeshow event handler

--- a/examples/wearable/UIComponents/contents/navigationelements/scrollbar/index.html
+++ b/examples/wearable/UIComponents/contents/navigationelements/scrollbar/index.html
@@ -30,6 +30,11 @@
 						Fast scroll
 					</a>
 				</li>
+				<li>
+					<a href="circularly-vertical-bar.html">
+						Circularly vertical bar
+					</a>
+				</li>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/912
[Problem] No circular scrollbar example
[Solution] Move rotary scrolling example from Etc.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>