### PR TITLE
Page transition has been disabled for mobile profile

### DIFF
--- a/src/js/profile/mobile/config.js
+++ b/src/js/profile/mobile/config.js
@@ -32,7 +32,7 @@
 			ns.setConfig("loader", false, true);
 			ns.setConfig("pageContainerBody", true, true);
 			ns.setConfig("popupTransition", "slideup", true);
-			ns.setConfig("pageTransition", "slide", true);
+			ns.setConfig("pageTransition", "none", true);
 			ns.setConfig("enablePageScroll", false, true);
 			//>>excludeStart("tauBuildExclude", pragmas.tauBuildExclude);
 			return ns;

--- a/tests/js/core/defaults/mobile/defaults.js
+++ b/tests/js/core/defaults/mobile/defaults.js
@@ -17,10 +17,10 @@
 			equal(defaults.dynamicBaseEnabled, false, "defaults.dynamicBaseEnabled after change");
 			defaults.dynamicBaseEnabled = true;
 
-			equal(defaults.pageTransition, "slide", "defaults.pageTransition");
+			equal(defaults.pageTransition, "none", "defaults.pageTransition");
 			defaults.pageTransition = "slidedown";
 			equal(defaults.pageTransition, "slidedown", "defaults.pageTransition after change");
-			defaults.pageTransition = "slide";
+			defaults.pageTransition = "none";
 
 			equal(defaults.popupTransition, "slideup", "defaults.popupTransition");
 			defaults.popupTransition = "slidedown";

--- a/tests/js/profile/mobile/config/config.js
+++ b/tests/js/profile/mobile/config/config.js
@@ -8,7 +8,7 @@ function runTests(tau) {
 		equal(tau.getConfig("loader"), false, "loader is set correct");
 		equal(tau.getConfig("pageContainerBody"), true, "pageContainerBody is set correct");
 		equal(tau.getConfig("popupTransition"), "slideup", "popupTransition is set correct");
-		equal(tau.getConfig("pageTransition"), "slide", "pageTransition is set correct");
+		equal(tau.getConfig("pageTransition"), "none", "pageTransition is set correct");
 	});
 }
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/878
[Problem] Page transition is not described in guideline for one ui.
   Page transition makes issues with MainTab.
[Solution] Default page transition in config file for mobile profile
 has been set to "none"

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>