### PR TITLE
TimePicker (mobile): Apply a two digits for minute picker

### DIFF
--- a/src/js/profile/mobile/widget/TimePicker.js
+++ b/src/js/profile/mobile/widget/TimePicker.js
@@ -168,6 +168,7 @@
 				} else if (name === "minute") {
 					options.min = 0;
 					options.max = 59;
+					options.digits = 2;
 					spinContainer.classList.add(TimePicker.classes.MINUTE_CONTAINER);
 				}
 


### PR DESCRIPTION
[Issue] N/A
[Problem] Minute picker appears as a single digit
[Solution] Change option of the Minute Picker to use the two digits

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>