### PR TITLE
Page (mobile): Fix to calculate the correct size of header

### DIFF
--- a/src/js/core/widget/core/Page.js
+++ b/src/js/core/widget/core/Page.js
@@ -474,7 +474,7 @@
 					//>>excludeEnd("tauDebug");
 
 					if (header) {
-						top = utilsDOM.getElementHeight(header);
+						top = utilsDOM.getElementHeight(header, null, false, true);
 					}
 
 					if (footer) {


### PR DESCRIPTION
[Issue] N/A
[Problem] The height of the content is not set properly
[Solution] Calculate to reflect the size of the margin

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>