### PR TITLE
(UIComponents) Fix for url of link in "contained" button example

### DIFF
--- a/examples/mobile/UIComponents/components/buttons/contained/index.html
+++ b/examples/mobile/UIComponents/components/buttons/contained/index.html
@@ -24,7 +24,7 @@
 					</a>
 				</li>
 				<li class="ui-li-anchor">
-					<a href="list_area/contained-list.html">
+					<a href="list-area/contained-list.html">
 						List Area
 					</a>
 				</li>


### PR DESCRIPTION
[Issue] SAD-799
[Problem] "List area" doesn't work in button example
[Solution] Wrong link has been corrected

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>