### PR TITLE
UIComponents (TextInput): save data on "Save" button

### DIFF
--- a/examples/wearable/UIComponents/contents/user-inputs-elements/textinput/text-input.js
+++ b/examples/wearable/UIComponents/contents/user-inputs-elements/textinput/text-input.js
@@ -4,6 +4,7 @@
 		inputName = page.querySelector("input[name=\"name\"]"),
 		inputPhone = page.querySelector("input[name=\"phonenumber\"]"),
 		inputPhone2 = page.querySelector("input[name=\"phonenumber2\"]"),
+		saveButton = page.querySelector(".ui-btn"),
 		nameWidget,
 		phoneWidget,
 		phone2Widget;
@@ -12,12 +13,25 @@
 		nameWidget = tau.widget.TextInput(inputName);
 		phoneWidget = tau.widget.TextInput(inputPhone);
 		phone2Widget = tau.widget.TextInput(inputPhone2);
+		saveButton.addEventListener("vclick", saveData);
+
+		inputName.value = window.sessionStorage.getItem("name");
+		inputPhone.value = window.sessionStorage.getItem("phone1");
+		inputPhone2.value = window.sessionStorage.getItem("phone2");
+	}
+
+	function saveData() {
+		window.sessionStorage.setItem("name", inputName.value);
+		window.sessionStorage.setItem("phone1", inputPhone.value);
+		window.sessionStorage.setItem("phone2", inputPhone2.value);
+		tau.back();
 	}
 
 	function destroy() {
 		nameWidget.destroy();
 		phoneWidget.destroy();
 		phone2Widget.destroy();
+		saveButton.removeEventListener("vclick", saveData);
 	}
 
 	page.addEventListener("pagebeforeshow", init);


### PR DESCRIPTION
[Issue] N/A (JIRA issue)

[Problem] After click on "Save" button, nothing happens but
	expectation is that inserted data are saved and current page
	disappears. Also saved data should be filled if user navigates
	back to this page.

[Solution]
	Save data on "Save" button and navigate back. Fill the data on
	page start if they are available.
	window.sessionStorage has been used so data are available during
	session which means after application restart data are gone and
	user/tester is not confused by seeing data entered long time ago.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>