### PR TITLE
[mobile] Add padding to Date picker (Calendar view)

### DIFF
--- a/src/css/profile/mobile/common/calendar.less
+++ b/src/css/profile/mobile/common/calendar.less
@@ -99,7 +99,6 @@
 
 		div.ui-calendar-switch {
 			text-align: center;
-			text-decoration: underline;
 			.font(regular);
 			font-size: 17 * @sp_base;
 			color: var(--calendar-text-color);
@@ -132,7 +131,7 @@
 		}
 	}
 	@media (min-width: 361px) {
-		.controller {
+		&-controller {
 			width: 328 * @px_base;
 			margin: 0 auto;
 		}

--- a/src/css/profile/mobile/common/listview.less
+++ b/src/css/profile/mobile/common/listview.less
@@ -51,6 +51,10 @@ tau-expandable {
 			min-height: 0;
 			margin-bottom: 108 * @px_base;
 		}
+
+		.ui-calendar {
+			padding: 14 * @px_base 16 * @px_base;
+		}
 	}
 
 	li {


### PR DESCRIPTION
- padding: 14px 16px added.
- date underline removed.
- when screen width: 361+, fix width 328px.