### PR TITLE
(UIComponents) fix for Master On-Off example

### DIFF
--- a/examples/mobile/UIComponents/components/controllers/master-onoffswitch.html
+++ b/examples/mobile/UIComponents/components/controllers/master-onoffswitch.html
@@ -49,32 +49,6 @@
 						</select>
 					</div>
 				</li>
-				<li class="ui-li-divider">
-					<div class="ui-li-text">
-						<span class="ui-li-text-title">
-							Switch on disabled
-						</span>
-					</div>
-					<div class="ui-li-action">
-						<select class="ui-on-off-switch" disabled>
-							<option value="off"></option>
-							<option value="on" selected></option>
-						</select>
-					</div>
-				</li>
-				<li>
-					<div class="ui-li-text">
-						<span class="ui-li-text-title">
-							Switch off disabled
-						</span>
-					</div>
-					<div class="ui-li-action">
-						<select class="ui-on-off-switch" disabled>
-							<option value="off" selected></option>
-							<option value="on"></option>
-						</select>
-					</div>
-				</li>
 			</ul>
 		</div>
 		<link href="onoffswitch.css" rel="stylesheet" />


### PR DESCRIPTION
[Issue] SAD-801
[Problem] Wrong description "Switch off disabled" when it is enabled and on
[Solution] Master On-Off example in UIComponents has been changed.
 Disabled by default On-Off switches have been removed because make logical conflict
 with Master Switch On-Off widget. That case is not described by UX guideline.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>