### PR TITLE
Fix for getPrefixedStyleValue method

### DIFF
--- a/src/js/core/util/DOM/css.js
+++ b/src/js/core/util/DOM/css.js
@@ -350,10 +350,10 @@
 
 			/**
 			 * Returns style value for css property with browsers prefixes
-			 * @method getPrefixedStyle
+			 * @method getPrefixedStyleValue
 			 * @param {HTMLStyle} styles
 			 * @param {string} property
-			 * @return {Object}
+			 * @return {string|undefined}
 			 * @member ns.util.DOM
 			 * @static
 			 */
@@ -366,7 +366,7 @@
 					if (prefixedProperties.hasOwnProperty(key)) {
 						value = styles[prefixedProperties[key]];
 						if (value && value !== "none") {
-							return value;
+							break;
 						}
 					}
 				}


### PR DESCRIPTION
[Issue] SVACE-609482
[Problem] Function always returns the same value
[Solution] Method has been changed. "Return" statment was
 changed to "break" loop.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>