### PR TITLE
UIComponents (Pickers): save Date/Time on "Set" button

### DIFF
--- a/examples/wearable/UIComponents/contents/user-inputs-elements/pickers/date-picker.js
+++ b/examples/wearable/UIComponents/contents/user-inputs-elements/pickers/date-picker.js
@@ -2,13 +2,26 @@
 (function () {
 	var page = document.getElementById("date-picker-page"),
 		element = page.querySelector(".ui-date-picker"),
-		widget = null;
+		widget = null,
+		SAVED_DATE_KEY = "SAVED-DATE-KEY",
+		savedDateValue = null;
 
 	function init() {
 		widget = tau.widget.DatePicker(element);
+		element.addEventListener("change", onChange);
+
+		savedDateValue = window.sessionStorage.getItem(SAVED_DATE_KEY);
+		if (savedDateValue) {
+			widget.value(new Date(savedDateValue));
+		}
+	}
+
+	function onChange(event) {
+		window.sessionStorage.setItem(SAVED_DATE_KEY, event.detail.value);
 	}
 
 	function onPageHide() {
+		element.removeEventListener("change", onChange);
 		widget.destroy();
 	}
 

--- a/examples/wearable/UIComponents/contents/user-inputs-elements/pickers/time-picker.js
+++ b/examples/wearable/UIComponents/contents/user-inputs-elements/pickers/time-picker.js
@@ -2,13 +2,26 @@
 (function () {
 	var page = document.getElementById("number-picker-page"),
 		element = page.querySelector(".ui-time-picker"),
-		widget = null;
+		widget = null,
+		SAVED_TIME_12_KEY = "SAVED-TIME-12-KEY",
+		savedTimeValue = null;
 
 	function init() {
 		widget = tau.widget.TimePicker(element);
+		element.addEventListener("change", onChange);
+
+		savedTimeValue = window.sessionStorage.getItem(SAVED_TIME_12_KEY);
+		if (savedTimeValue) {
+			widget.value(new Date(savedTimeValue));
+		}
+	}
+
+	function onChange(event) {
+		window.sessionStorage.setItem(SAVED_TIME_12_KEY, event.detail.value);
 	}
 
 	function onPageHide() {
+		element.removeEventListener("change", onChange);
 		widget.destroy();
 	}
 

--- a/examples/wearable/UIComponents/contents/user-inputs-elements/pickers/time-picker24.js
+++ b/examples/wearable/UIComponents/contents/user-inputs-elements/pickers/time-picker24.js
@@ -2,13 +2,26 @@
 (function () {
 	var page = document.getElementById("number-picker-page"),
 		element = page.querySelector(".ui-time-picker"),
-		widget = null;
+		widget = null,
+		SAVED_TIME_24_KEY = "SAVED-TIME-24-KEY",
+		savedTimeValue = null;
 
 	function init() {
 		widget = tau.widget.TimePicker(element);
+		element.addEventListener("change", onChange);
+
+		savedTimeValue = window.sessionStorage.getItem(SAVED_TIME_24_KEY);
+		if (savedTimeValue) {
+			widget.value(new Date(savedTimeValue));
+		}
+	}
+
+	function onChange(event) {
+		window.sessionStorage.setItem(SAVED_TIME_24_KEY, event.detail.value);
 	}
 
 	function onPageHide() {
+		element.removeEventListener("change", onChange);
 		widget.destroy();
 	}
 


### PR DESCRIPTION
[Issue] SAD-798
[Problem] After click on button "Set", current Date or Time is not saved
	for the Date and Time pickers.
[Solution] Save the date/time to sessionStorage and restore it on "pageshow".

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>