### PR TITLE
List (mobile): Add a height between title and sub text

### DIFF
--- a/src/css/profile/mobile/common/listview.less
+++ b/src/css/profile/mobile/common/listview.less
@@ -173,6 +173,13 @@ tau-expandable {
 				color: var(--text-secondary-color);
 				line-height: 15 * @px_base;
 
+				// line height between title and sub
+				&+.ui-li-text-title::before {
+					content: "";
+					display: block;
+					height: 4 * @px_base;
+				}
+
 				img {
 					width: 15 * @px_base;
 					height: 15 * @px_base;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/980
[Problem] There is no margin when the sub text is placed upper title text
[Solution] Add a height to match with GUI feedback

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>