### PR TITLE
Fix for icon color for button in AppBar widget

### DIFF
--- a/src/css/profile/mobile/common/button.less
+++ b/src/css/profile/mobile/common/button.less
@@ -287,6 +287,10 @@ a.ui-btn {
 			width: 208 * @unit_base;
 		}
 
+		&::after {
+			background-color: var(--button-icon-color);
+		}
+
 		&.ui-btn-active {
 			&::after {
 				background-color: @color_button_icon_press;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/998
[Problem] Icons in AppBar disappeared
[Solution] Icons lost background color

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>