### PR TITLE
(svace) ToggleSwitch.extra - remove unnecesary "return"

### DIFF
--- a/src/js/support/mobile/widget/ToggleSwitch.extra.js
+++ b/src/js/support/mobile/widget/ToggleSwitch.extra.js
@@ -413,19 +413,15 @@
 			function onVmousedownRefresh(self, event) {
 				var element = self.element;
 
-				if (self.options.disabled) {
-					return false;
+				if (!self.options.disabled) {
+					self._dragging = true;
+					self._userModified = false;
+					self._mouseMoved = false;
+					if (element.nodeName.toLowerCase() === "select") {
+						self._beforeStart = element.selectedIndex;
+					}
+					refresh(self, event);
 				}
-
-				self._dragging = true;
-				self._userModified = false;
-				self._mouseMoved = false;
-				//element.nodeName.toLowerCase()
-				if (element.nodeName.toLowerCase() === "select") {
-					self._beforeStart = element.selectedIndex;
-				}
-				refresh(self, event);
-				return false;
 			}
 
 			/**


### PR DESCRIPTION
[Issue] SCAVE-609511
[Problem] SonarJS issue S3516 - function always returns the same value
[Solution] Remove "return" statement because it wasn't necessary

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>