### PR TITLE
Fix for footer with buttons

### DIFF
--- a/examples/mobile/UIComponents/components/buttons/contained/body-area/2-buttons.html
+++ b/examples/mobile/UIComponents/components/buttons/contained/body-area/2-buttons.html
@@ -13,7 +13,7 @@
 	<div class="ui-page" id="ContainedButtonsBodyArea2Buttons">
 		<div class="ui-content">
 		</div>
-		<footer>
+		<footer class="ui-bottom-button">
 			<button data-style="contained">
 				Button
 			</button>

--- a/src/css/profile/mobile/common/core.less
+++ b/src/css/profile/mobile/common/core.less
@@ -134,11 +134,6 @@
 	overflow-y: visible;
 	overflow-x: hidden;
 	flex-shrink: 1;
-	mask-border: url(images/0_Round_corner/round.svg) 77;
-	mask-border-width: 26 * @px_base;
-	border-radius: 26 * @px_base;
-	box-sizing: border-box;
-	box-shadow: 0 0 0 0.25 * @px_base var(--content-area-line-color) inset;
 
 	&.ui-content-padding {
 		&, &.ui-scrollview-clip {

--- a/src/css/profile/mobile/common/footer.less
+++ b/src/css/profile/mobile/common/footer.less
@@ -45,6 +45,11 @@
 			}
 		}
 	}
+	&.ui-bottom-button {
+		height: 56 * @px_base;
+		padding-left: 24 * @px_base;
+		padding-right: 24 * @px_base;
+	}
 }
 
 .ui-footer {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1028
[Problem] Line crossing buttons visible
[Solution] Height of footer with buttons wasn't defined
 + added padding at the left/right side according to the guideline
 + removing border line from ui-content class

![obraz](https://user-images.githubusercontent.com/29534410/80469549-005a0300-8941-11ea-824f-8d97e8079a4d.png)



Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>