### PR TITLE
Remove disabled examples for on-off switch and radio button

### DIFF
--- a/examples/wearable/UIComponents/contents/user-inputs-elements/controls/onoff-switch.html
+++ b/examples/wearable/UIComponents/contents/user-inputs-elements/controls/onoff-switch.html
@@ -45,26 +45,6 @@
 						</div>
 					</label>
 				</li>
-				<li class="li-has-toggle">
-					<label>
-						Wi-Fi
-						<div class="ui-toggleswitch">
-							<input class="ui-switch-input" type="checkbox" checked disabled/>
-							<div class="ui-switch-button">
-							</div>
-						</div>
-					</label>
-				</li>
-				<li class="li-has-toggle">
-					<label>
-						NFC
-						<div class="ui-toggleswitch">
-							<input class="ui-switch-input" type="checkbox" disabled/>
-							<div class="ui-switch-button">
-							</div>
-						</div>
-					</label>
-				</li>
 			</ul>
 		</div>
 	</div>

--- a/examples/wearable/UIComponents/contents/user-inputs-elements/controls/radio.html
+++ b/examples/wearable/UIComponents/contents/user-inputs-elements/controls/radio.html
@@ -32,18 +32,6 @@
                         <input type="radio" id="radio-2" name="radio-el" />
                     </label>
                 </li>
-                <li class="li-has-radio">
-                    <label>
-                        Radio on disabled
-                        <input type="radio" checked="checked" name="radio-dim" disabled/>
-                    </label>
-                </li>
-                <li class="li-has-radio">
-                    <label>
-                        Radio off disabled
-                        <input type="radio" name="radio-dim" disabled/>
-                    </label>
-                </li>
             </ul>
         </div>
         <script src="radio.js">


### PR DESCRIPTION
[Issue] #1034
[Problem] Disabled on/off switch has rendering issue #1034
[Solution] Remove disabled examples for on-off switch and checkbox controls. They are not in guideline.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>