### PR TITLE
Recover rounded corners on ui-content element

### DIFF
--- a/src/css/profile/mobile/common/core.less
+++ b/src/css/profile/mobile/common/core.less
@@ -134,6 +134,9 @@
 	overflow-y: visible;
 	overflow-x: hidden;
 	flex-shrink: 1;
+	mask-border: url(images/0_Round_corner/round.svg) 77;
+	mask-border-width: 26 * @px_base;
+	border-radius: 26 * @px_base;
 
 	&.ui-content-padding {
 		&, &.ui-scrollview-clip {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1028
[Problem] ui-content element should have rounded corners
[Solution] Recovery rounded corners on ui-content element

![obraz](https://user-images.githubusercontent.com/29534410/80566792-0957dc80-89f4-11ea-8a97-2f32bc451ba2.png)

![obraz](https://user-images.githubusercontent.com/29534410/80566872-386e4e00-89f4-11ea-80aa-271a07c8338c.png)



Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>