### PR TITLE
Slider focus outline is out of guideline

### DIFF
--- a/src/css/profile/mobile/common/slider.less
+++ b/src/css/profile/mobile/common/slider.less
@@ -19,7 +19,7 @@
 	}
 
 	&:focus {
-		outline: 4 * @unit_base solid @color_focus_border;
+		outline: none;
 	}
 
 	.ui-slider-handler-track {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/893
[Problem] Focus outline is not described in guideline
[Solution]
 - outline style has been removed

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>