### PR TITLE
Contained button: Fix for max width for screen 673+

### DIFF
--- a/examples/mobile/UIComponents/components/buttons/contained/body-area/contained-body.html
+++ b/examples/mobile/UIComponents/components/buttons/contained/body-area/contained-body.html
@@ -17,13 +17,16 @@
 			</h1>
 		</div>
 		<div class="ui-content">
-            <button data-style="contained">Default width (60%)</button>
+			<button data-style="contained">Default width (60%)</button>
+			<br/>
+			<br/>
+			<button data-style="contained" style="width: auto;">Min width</button>
             <br/>
             <br/>
-            <button data-style="contained" style="width: 100%">Max. (default) width (75%)</button>
+            <button data-style="contained" style="width: 100%">Max. (default) width</button>
             <br/>
             <br/>
-            <button data-style="contained">
+            <button data-style="contained" style="width: 100%">
 				Multiline button max 2 lines, Multiline button max 2 lines, Multiline button max 2 lines
 			</button>
 	</div>

--- a/src/css/profile/mobile/common/button.less
+++ b/src/css/profile/mobile/common/button.less
@@ -567,6 +567,15 @@ a.ui-btn {
 	}
 }
 
+@media all and (min-width: 673px) and (min-height: 411px) {
+	.ui-btn {
+		&.ui-btn-contained:not(.ui-btn-inline) {
+			max-width: 60%;
+			min-width: 240 * @px_base;
+		}
+	}
+}
+
 .ui-listview {
 	li {
 		&.ui-li-has-btn {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1016
[Problem] Wrong buttons width for 673x411
[Solution]
 - Max width of contained button is different for different
  screen size

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>