### PR TITLE
Drop Down Menu: fix for left position for screen 673+

### DIFF
--- a/src/js/profile/mobile/widget/DropdownMenu.js
+++ b/src/js/profile/mobile/widget/DropdownMenu.js
@@ -1032,6 +1032,7 @@
 					// maxHeight,
 					widgetParent = ui.elSelectWrapper.parentNode,
 					widgetParentStyle = window.getComputedStyle(widgetParent),
+					widgetParentRect = widgetParent.getBoundingClientRect(),
 					hiddenPart = 0, // hidden part of selected list element
 					maxContainerWidth;
 
@@ -1042,7 +1043,7 @@
 				height = optionHeight;
 
 				// This part decides the location and direction of option list.
-				offsetLeft = self._horizontalPosition === "right" ? window.screen.width - width : 0;
+				offsetLeft = self._horizontalPosition === "right" ? widgetParentRect.right - width : widgetParentRect.left;
 				optionStyle = "left: " + offsetLeft + "px; ";
 
 				if (options.inline === true) {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1022
[Problem] Wrong position of DropDownMenu for screens 673+
[Solution]
 - left / right position of drop down menue has been changed

[Result]
![obraz](https://user-images.githubusercontent.com/29534410/80948531-9505aa80-8df2-11ea-91d0-b279b6056373.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>