### PR TITLE
AppBar: disallow expand for screen below height 579

### DIFF
--- a/src/css/profile/mobile/common/appbar.less
+++ b/src/css/profile/mobile/common/appbar.less
@@ -25,6 +25,14 @@
 			padding-top: 0 * @px_base;
 			transition: opacity 100ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
 		}
+
+		&.ui-appbar-animation-fast {
+			transition-duration: 10ms;
+			.ui-appbar-controls-container,
+			.ui-appbar-expanded-title-container {
+				transition-duration: 10ms;
+			}
+		}
 	}
 
 	.ui-btn {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1025
[Problem] extended appbar should not be applied for height up to 579
[Solution]
 - added new method .expand(), .collapse()
 - added listeners for resize
 - added refresh page content
 - added options for disable animation and disable expanding

[Test use case]
- open UIComponents > Lists > List Content area
- Expand AppBar by drag
- change device orientation to landscape
Result: The AppBar should be collapsed.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>