### PR TITLE
AssistPanel: fix for onclick handler and fix for example

### DIFF
--- a/examples/wearable/UIComponents/contents/navigationelements/assist-panel.html
+++ b/examples/wearable/UIComponents/contents/navigationelements/assist-panel.html
@@ -24,7 +24,7 @@
 			<ul class="ui-listview">
 				<li>
 					<a href="#" data-rel="back">
-						Assist Panel Item 1
+						Panel Item 1
 					</a>
 				</li>
 			</ul>

--- a/src/js/profile/wearable/widget/wearable/AssistPanel.js
+++ b/src/js/profile/wearable/widget/wearable/AssistPanel.js
@@ -232,17 +232,16 @@
 				var self = this,
 					callbacks = self._callbacks;
 
-				callbacks.onClick = onClick.bind(self);
-				CoreAssistPanel.prototype._bindEvents.call(this);
+				callbacks.onClick = onClick.bind(null, self);
+				CoreAssistPanel.prototype._bindEvents.call(self);
 
-				this._ui.indicator.addEventListener("vclick", callbacks.onClick);
+				self._ui.indicator.addEventListener("vclick", callbacks.onClick);
 			};
 
 			prototype._unbindEvents = function () {
-				var self = this,
-					callbacks = self._callbacks;
+				var self = this;
 
-				this._ui.indicator.removeEventListener("vclick", callbacks.onClick);
+				self._ui.indicator.removeEventListener("vclick", self._callbacks.onClick);
 			};
 
 			prototype._destroy = function () {


### PR DESCRIPTION
[Issue] SAD-802
[Problem] Text is cut in example
[Solution]
 - Text has been modified
 - Fix for onclick handler (wrong binding)

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>