### PR TITLE
Remove empty Progress menu in etc

### DIFF
--- a/examples/mobile/UIComponents/components/etc/index.html
+++ b/examples/mobile/UIComponents/components/etc/index.html
@@ -36,12 +36,6 @@
 						Graphs
 					</a>
 				</li>
-				<!-- @todo need to review below samples -->
-				<li class="ui-li-anchor">
-					<a href="progress/index.html">
-						Progress
-					</a>
-				</li>
 				<li class="ui-li-anchor">
 					<a href="interactive/index.html">
 						Interactive


### PR DESCRIPTION
[Issue] N/A
[Problem] Progress menu in Etc was leading to not existing location
[Solution] Remove menu.
[Remark] Progress menu is already located in main menu.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>