### PR TITLE
(build process) Postcss: increase versions of browser backward compatibility

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -749,7 +749,7 @@ module.exports = function (grunt) {
 			postcss: {
 				options: {
 					processors: [
-						autoprefixer({browsers: "last 10 Samsung versions, last 10 versions, last 10 ChromeAndroid versions"})
+						autoprefixer({browsers: "last 12 Samsung versions, last 12 versions, last 12 ChromeAndroid versions"})
 					]
 				},
 				dist: {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1094
[Problem] UIComponents doesn't work after TAU build
[Solution]
 - part of prefixed styles have been removed because have been
  recognized as standard supported

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>