### PR TITLE
Spin and Appbar: lockExpanding on Spin drag

### DIFF
--- a/src/js/core/widget/core/Appbar.js
+++ b/src/js/core/widget/core/Appbar.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*global window, define, ns */
+/*global define, ns */
 /**
  *
  * @since 1.2
@@ -64,6 +64,7 @@
 					self._dragStartingHeight = 0;
 					self._currentHeight = 0;
 					self._scrolledToTop = true;
+					self._lockExpanding = false;
 					self._calculateExtendedHight();
 				},
 				BaseWidget = ns.widget.BaseWidget,
@@ -119,6 +120,7 @@
 			Appbar.prototype = prototype;
 			Appbar.defaults = defaults;
 			Appbar.classes = classes;
+			Appbar.selector = ".ui-appbar,.ui-header,header,[data-role='header']";
 
 			prototype._init = function (element) {
 				var self = this;
@@ -382,7 +384,7 @@
 			prototype._onDragStart = function (event) {
 				var self = this;
 
-				if (self.options.expandingEnabled && (
+				if (!self._lockExpanding && self.options.expandingEnabled && (
 					(event.detail.direction === "down" && self._appbarState == states.COLLAPSED && self._scrolledToTop) ||
 					(event.detail.direction === "up" && self._appbarState == states.EXPANDED))) {
 
@@ -471,6 +473,19 @@
 			};
 
 			/**
+			 * Lock/Unlock AppBar expanding
+			 * Developer can temporarily locks AppBar expanding,
+			 * eg. when a widget in page content requires it
+			 * @method lockExpanding
+			 * @param {boolean} lock
+			 * @member ns.widget.core.Appbar
+			 * @public
+			 */
+			prototype.lockExpanding = function (lock) {
+				this._lockExpanding = !!lock;
+			};
+
+			/**
 			 * Dragend event handler
 			 * @method _onDragEnd
 			 * @member ns.widget.core.Appbar
@@ -480,7 +495,7 @@
 				var self = this,
 					threshold
 
-				if (self.options.expandingEnabled) {
+				if (!self._lockExpanding && self.options.expandingEnabled) {
 					threshold = (nominalHeights.COLLAPSED + self._expandedHeight) / 2;
 					self.element.classList.remove(classes.dragging);
 
@@ -508,7 +523,7 @@
 					totalHeight = self._dragStartingHeight + ((deltaY !== undefined) ? deltaY : 0),
 					totalMovement = 0;
 
-				if (self._appbarState === states.DRAGGING) {
+				if (!self._lockExpanding && self._appbarState === states.DRAGGING) {
 					totalHeight = min(totalHeight, self._expandedHeight);
 					totalHeight = max(totalHeight, nominalHeights.COLLAPSED);
 
@@ -764,7 +779,7 @@
 			ns.widget.core.Appbar = Appbar;
 			ns.engine.defineWidget(
 				"Appbar",
-				".ui-appbar,.ui-header,header,[data-role='header']",
+				Appbar.selector,
 				[],
 				Appbar,
 				"core"

--- a/src/js/core/widget/core/Spin.js
+++ b/src/js/core/widget/core/Spin.js
@@ -36,12 +36,16 @@
 		"../../../core/engine",
 		"../../../core/util/animation/animation",
 		"../../../core/event/gesture",
-		"../../../core/util/selectors"
+		"../../../core/util/selectors",
+		"./Page",
+		"./Appbar"
 	],
 	function () {
 		//>>excludeEnd("tauBuildExclude");
 		var document = window.document,
 			BaseWidget = ns.widget.BaseWidget,
+			Page = ns.widget.core.Page,
+			Appbar = ns.widget.core.Appbar,
 			engine = ns.engine,
 			utilsEvents = ns.event,
 			gesture = utilsEvents.gesture,
@@ -112,7 +116,9 @@
 					dragTarget: "document" // "document" | "self"
 				};
 				self._ui = {
-					scrollableParent: null
+					scrollableParent: null,
+					page: null,
+					appbar: null
 				};
 				self.length = self.options.max - self.options.min + 1;
 				self._prevValue = null; // self property has to be "null" on start
@@ -575,13 +581,20 @@
 				self._overflowYBeforeDrag = ui.scrollableParent.style.overflowY;
 				ui.scrollableParent.style.overflowY = "hidden";
 			}
+			ui.page = utilSelectors.getClosestBySelector(self.element, Page.selector);
+			if (ui.page) {
+				ui.appbar = ui.page.querySelector(Appbar.selector);
+				if (ui.appbar) {
+					ns.widget.Appbar(ui.appbar).lockExpanding(true);
+				}
+			}
 		};
 
 		/**
 		 * Handler for mouse up / touch end event
 		 * The method is intended to unblock the scroll after drag event on Spin widget
 		 * @protected
-		 * @method _vmouseDown
+		 * @method _vmouseUp
 		 * @member ns.widget.core.Spin
 		 */
 		prototype._vmouseUp = function () {
@@ -590,6 +603,9 @@
 
 			if (ui.scrollableParent) {
 				ui.scrollableParent.style.overflowY = self._overflowYBeforeDrag;
+			}
+			if (ui.appbar) {
+				ns.widget.Appbar(ui.appbar).lockExpanding(false);
 			}
 		};
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1111
[Problem] After extending app bar problem with manipulation of
 date & time picker
[Solution]
 - added new method "lockExpanding()" to Appbar
 - lock Appbar expanding during Spin drag

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>