### PR TITLE
(mobile) Calendar: padding added to calendar in content are

### DIFF
--- a/src/css/profile/mobile/common/calendar.less
+++ b/src/css/profile/mobile/common/calendar.less
@@ -138,3 +138,9 @@
 	}
 	
 }
+
+.ui-content-area {
+	.ui-calendar {
+		padding: 14 * @px_base 16 * @px_base;
+	}
+}

--- a/src/css/profile/mobile/common/listview.less
+++ b/src/css/profile/mobile/common/listview.less
@@ -51,10 +51,6 @@ tau-expandable {
 			min-height: 0;
 			margin-bottom: 108 * @px_base;
 		}
-
-		.ui-calendar {
-			padding: 14 * @px_base 16 * @px_base;
-		}
 	}
 
 	li {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1127
[Problem] Calendar on content area without listview has not padding
[Solution]
 - the padding has been moved from listview to content are generally

![obraz](https://user-images.githubusercontent.com/29534410/82640729-60278f00-9c0b-11ea-9228-0363fe194086.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>