### PR TITLE
DayOfWeekPicker: fix for button of days look wrong after reopen page

### DIFF
--- a/examples/mobile/ScheduleApp/js/DayOfWeekPicker.js
+++ b/examples/mobile/ScheduleApp/js/DayOfWeekPicker.js
@@ -71,6 +71,7 @@
 		element.classList.add(classes.WIDGET);
 		for (i = 0; i < 7; i++) {
 			checkbox = document.createElement("input");
+			checkbox.setAttribute("data-role", "none");
 			checkbox.setAttribute("type", "checkbox");
 			fragment.appendChild(checkbox);
 			ui.days[i] = checkbox;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1117
[Problem] DayOfWeekPicker: button of days look wrong after reopen page
[Solution]
 - prevent build tau checkbox inside DayOfWeek widget

[Depends on]
https://github.com/Samsung/TAU/pull/1133
