### PR TITLE
OnOffSwitch: fix for broken look after re-open page

### DIFF
--- a/src/js/core/widget/core/OnOffSwitch.js
+++ b/src/js/core/widget/core/OnOffSwitch.js
@@ -230,6 +230,7 @@
 				var inputElement = createElement("input");
 
 				inputElement.type = "checkbox";
+				inputElement.setAttribute("data-role", "none");
 				return inputElement;
 			}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1116
[Problem] Broken On-Off switch after re-open page
[Solution]
 - prevent re-build checkbox created inside on-off switch

[Depends on]
https://github.com/Samsung/TAU/pull/1133