### PR TITLE
TimePicker, DataTimePicker: fix for inactive input bg color

### DIFF
--- a/src/css/profile/mobile/common/datetimepicker.less
+++ b/src/css/profile/mobile/common/datetimepicker.less
@@ -81,6 +81,7 @@
 			outline-offset: unset;
 			text-shadow: 0 0 0 var(--primary-dark-color);
 			opacity: 0;
+			background-color: transparent;
 
 			&:focus {
 				background-color: var(--primary-color-20p);

--- a/src/css/profile/mobile/common/timepicker.less
+++ b/src/css/profile/mobile/common/timepicker.less
@@ -69,6 +69,7 @@
 			outline-offset: unset;
 			text-shadow: 0 0 0 var(--primary-dark-color);
 			opacity: 0;
+			background-color: transparent;
 
 			&:focus {
 				background-color: var(--primary-color-20p);


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1163
[Problem] Date and Time picker - white box issue
[Solution] Background color has been fixed to transparent

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>