### PR TITLE
Remove the focus box after clicking the button

### DIFF
--- a/src/css/profile/mobile/common/button.less
+++ b/src/css/profile/mobile/common/button.less
@@ -198,6 +198,10 @@ a.ui-btn {
 		content: "";
 	}
 
+	&:focus {
+		outline: none;
+	}
+
 	&:not(.ui-btn-nobg) {
 		&::before {
 			z-index: -1;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1162
[Problem] Orange outline box is shown after clicking the button
[Solution] Set the outline of the ui-btn to none

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>