### PR TITLE
(examples) ScheduleApp: fix for back button on the Add schedule page

### DIFF
--- a/examples/mobile/ScheduleApp/create-event.html
+++ b/examples/mobile/ScheduleApp/create-event.html
@@ -18,9 +18,7 @@
 	<div class="ui-page" id="create-event-page">
 		<header>
 			<div class="ui-appbar-left-icons-container">
-				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back">
-					<!-- @ToDo: back icon support -->
-				</a>
+				<a href="#main" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat"></a>
 			</div>
 			<div class="ui-appbar-title-container">
 				<span class="ui-appbar-title">


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1190
[Problem] Clicking back on the Add schedule screen has no effect
[Solution]
 - redirect back button to main page

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>