### PR TITLE
Proper shape for toast message

### DIFF
--- a/src/css/profile/mobile/common/toast.less
+++ b/src/css/profile/mobile/common/toast.less
@@ -13,7 +13,7 @@
 		left: 50%;
 		.transform(translate(-50%));
 		border: 2 * @unit_base solid @color_toast_stroke;
-		border-radius: 6 * @unit_base;
+		border-radius: 22 * @px_base;
 
 		padding: 11 * @unit_base 28 * @unit_base;
 		line-height: 41 * @unit_base;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1156
[Problem] Shape of toast message not in compliance with guide.
[Solution] Apply proper value of border-radius property

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>