### PR TITLE
Spin: fix for stop scroll on swipe

### DIFF
--- a/src/js/core/event/gesture/Manager.js
+++ b/src/js/core/event/gesture/Manager.js
@@ -213,7 +213,7 @@
 					detectors = [];
 
 				if (!self._isReadyDetecting) {
-					self._resetDetecting();
+					self.resetDetecting();
 					self._bindEvents();
 
 					startEvent = self._createDefaultEventData(gesture.Event.START, event);
@@ -287,7 +287,7 @@
 						this.unregister(_instance);
 					}, self);
 
-					self._resetDetecting();
+					self.resetDetecting();
 					self._blockMouseEvent = false;
 				}
 			},
@@ -314,7 +314,7 @@
 					this.unregister(_instance);
 				}, self);
 
-				self._resetDetecting();
+				self.resetDetecting();
 				self._blockMouseEvent = false;
 			},
 
@@ -380,11 +380,11 @@
 
 			/**
 			 * Reset of gesture manager detector
-			 * @method _resetDetecting
+			 * @method resetDetecting
 			 * @member ns.event.gesture.Manager
-			 * @protected
+			 * @public
 			 */
-			_resetDetecting: function () {
+			resetDetecting: function () {
 				var self = this;
 
 				self._isReadyDetecting = false;
@@ -596,7 +596,7 @@
 			_destroy: function () {
 				var self = this;
 
-				self._resetDetecting();
+				self.resetDetecting();
 				self.instances.length = 0;
 				self.unregisterBlockList.length = 0;
 				self._blockMouseEvent = false;

--- a/tests/js/core/event/gesture/Manager/Manager.js
+++ b/tests/js/core/event/gesture/Manager/Manager.js
@@ -626,8 +626,8 @@
 				return event;
 			};
 
-			manager._resetDetecting = function () {
-				ok(true, "_resetDetecting was called");
+			manager.resetDetecting = function () {
+				ok(true, "resetDetecting was called");
 			};
 
 			manager._bindEvents = function () {
@@ -664,8 +664,8 @@
 
 			manager.gestureDetectors = [];
 
-			manager._resetDetecting = function () {
-				ok(true, "_resetDetecting was called");
+			manager.resetDetecting = function () {
+				ok(true, "resetDetecting was called");
 			};
 
 			manager._createDefaultEventData = function (type, _event) {
@@ -704,8 +704,8 @@
 					touches: []
 				};
 
-			manager._resetDetecting = function () {
-				ok(true, "_resetDetecting was called");
+			manager.resetDetecting = function () {
+				ok(true, "resetDetecting was called");
 			};
 
 			manager._createDefaultEventData = function (type, _event) {
@@ -770,8 +770,8 @@
 		test("_destroy", 4, function () {
 			var manager = new Manager();
 
-			manager._resetDetecting = function () {
-				ok(true, "_resetDetecting was called");
+			manager.resetDetecting = function () {
+				ok(true, "resetDetecting was called");
 			};
 
 			manager._destroy();


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1168
[Problem] Spin / DateTimePicker stop scroll on long swipe
[Solution]
 - Increasing the number of carousel elements reduces this problem
 - added timeout for lack of dragEnd event and reset drag event detecting

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>