### PR TITLE
Fix small Time Picker on TV

### DIFF
--- a/src/css/profile/mobile/common/popup.less
+++ b/src/css/profile/mobile/common/popup.less
@@ -20,7 +20,7 @@
 	@media (min-width: 673px) and (max-width: 985px) {
 		width: 55%;
 	}
-	@media (min-width: 986px) and (max-width: 1919px) {
+	@media (min-width: 986px) {
 		width: 35%;
 	}
 


### PR DESCRIPTION
[Issue] N/A
[Problem] Time Picker is too small when UIComponets app from Mobile
	profile is launched on TV screen (1920x1080).
[Solution] Apply "width: 35%" for screen width greater than 986px.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>