### PR TITLE
Fix ui-content-area for TV

### DIFF
--- a/src/css/profile/mobile/common/core.less
+++ b/src/css/profile/mobile/common/core.less
@@ -147,10 +147,19 @@
 	}
 
 	.ui-content-area {
+		// Width for Tablet
+		@media (min-width: 673px) and (min-height: 411px) {
+			width: 90%;
+		}
+		@media (min-width: 960px) {
+			width: 75%;
+		}
+
 		background-color: var(--background-area-color);
 		border-radius: 26 * @px_base;
 		box-sizing: border-box;
 		box-shadow: 0 0 0 0.25 * @px_base var(--content-area-line-color) inset;
+		margin: auto;
 
 		&-disabled-top-rounding {
 			border-top-left-radius: 0;


### PR DESCRIPTION
[Issue] N/A
[Problem] "Repeat weekly" has different width than "Device On/Off" picker.
[Solution] Apply proper width to ui-content-area for Tablet and TV and center
	the element.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>