### PR TITLE
(UIComponents) Fix double back action in Dialogs

### DIFF
--- a/examples/mobile/UIComponents/components/dialogs/dialog.js
+++ b/examples/mobile/UIComponents/components/dialogs/dialog.js
@@ -1,6 +1,6 @@
 (function (document, tau) {
 	var page = document.getElementById("demo-dialog-page"),
-		buttons = document.querySelectorAll(".ui-btn"),
+		buttons = document.querySelectorAll(".ui-btn:not(.ui-btn-icon-back)"),
 		progressPage = page.querySelector("#progressbar-dialog"),
 		progressbar = page.querySelector("#progressbar"),
 		progressPercent = page.querySelector("#percent"),

--- a/examples/mobile/UIComponents/components/dialogs/picker.js
+++ b/examples/mobile/UIComponents/components/dialogs/picker.js
@@ -1,6 +1,6 @@
 (function (document, tau) {
 	var page = document.getElementById("demo-picker-page"),
-		buttons = document.querySelectorAll(".ui-btn"),
+		buttons = document.querySelectorAll(".ui-btn:not(.ui-btn-icon-back)"),
 		idx;
 
 	function onClick() {


### PR DESCRIPTION
[Issue] N/A
[Problem] User is navigated two pages backward adter click "back icon"
	in "Dialog -> General Dialog" or "Dialog -> Picker Dialogs".
[Solution] Exclude ".ui-btn-icon-back" from calling "tau.history.back"
	since it already does it.

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>