### PR TITLE
(mobile) OnOff Switch: fix for colord border of track

### DIFF
--- a/src/css/profile/mobile/common/onoffswitch.less
+++ b/src/css/profile/mobile/common/onoffswitch.less
@@ -101,6 +101,7 @@
         margin: 4.25 * @px_base 3 * @px_base;
         &:disabled {
             background-color: var(--on-off-switch-on-disabled-track-background);
+            border-color: transparent;
             & ~ .ui-on-off-switch-button {
                 border-color: var(--on-off-switch-on-disabled-button-border);
             }


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1223
[Problem] disabled state has colord border of track
[Solution]
 - color of border line of track has been changed to transparent

![obraz](https://user-images.githubusercontent.com/29534410/85257617-6a38e980-b466-11ea-93f9-a8c7420ef9db.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>