### PR TITLE
Let 'npm install' check node and build TAU

### DIFF
--- a/check-node.py
+++ b/check-node.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import json, subprocess, re, sys
+
+current_node_version = []
+expected_node_version = []
+
+def get_version(s):
+	return re.sub('[v\n]', '', s).split('.')
+
+def version_to_str(l):
+	s = '.'
+	s = s.join(l)
+	return s
+
+with open('package.json') as f:
+	data = json.load(f)
+expected_node_version = get_version(str(data['engines']['node']))
+
+try:
+	current_node_version = get_version(subprocess.check_output('node --version', shell=True))
+except subprocess.CalledProcessError as e:
+	print 'Could not get node version, Please install nvm and execute nvm use.'
+	print e.output
+	sys.exit(1)
+
+if len(current_node_version) < 2 or len(expected_node_version) < 2:
+	print 'Not enough information about node version.'
+	sys.exit(1)
+
+# Major and minor version are expected to be equal.
+if current_node_version[0] != expected_node_version[0] or current_node_version[1] != expected_node_version[1]:
+	print 'Current node version is %s but should be %s. Please install nvm and execute nvm use.' % (version_to_str(current_node_version), version_to_str(expected_node_version))
+	sys.exit(1)
+
+print 'Node version ok!'

--- a/package.json
+++ b/package.json
@@ -5,14 +5,18 @@
   "version": "1.2.5",
   "scripts": {
     "build": "grunt build",
+    "postinstall": "npm run build",
     "grunt": "grunt",
     "http-server": "http-server -p 8888 -a localhost",
-    "preinstall": "./install-hooks",
+    "preinstall": "./check-node.py && ./install-hooks",
     "test": "grunt test",
     "test:karma": "karma start tests/karma/all.conf.js",
     "test:karma-single-test": "karma start tests/karma/single.conf.js",
     "lint-check": "lint-diff $TRAVIS_COMMIT_RANGE",
     "spellcheck": "cspell 'src/**/*.js' 'src/**/*.html' 'examples/mobile/UIComponents/**/*.js' 'examples/wearable/UIComponents/**/*.js' 'examples/mobile/UIComponents/**/*.html' 'examples/wearable/UIComponents/**/*.html'"
+  },
+  "engines" : {
+	"node": "6.16"
   },
   "devDependencies": {
     "async": "^0.9.2",


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1179
[Problem] 'npm install' does not build TAU
[Solution] Modify preinstall script in order
	to check required node version (check-node.py).
	Build TAU after npm install

Signed-off-by: Grzegorz Czajkowski <g.czajkowski@samsung.com>