### PR TITLE
Router: fix for click on back button - prevent default action

### DIFF
--- a/src/js/core/history/manager.js
+++ b/src/js/core/history/manager.js
@@ -105,6 +105,7 @@
 					link = selectorUtils.getClosestBySelector(target, LINK_SELECTOR),
 					href,
 					useDefaultUrlHandling,
+					result = true,
 					options, // this should be empty object but some utils that work on it
 					rel; // require hasOwnProperty :(
 
@@ -130,17 +131,19 @@
 							options.link = link;
 						}
 						history.disableVolatileMode();
+						// mark as handled for back button
+						if (rel === "back") {
+							eventUtils.preventDefault(event);
+							result = false;
+						}
 						if (!triggerStateChange(options)) {
 							// mark as handled
-							// but not on back
-							if (!rel || (rel !== "back")) {
-								eventUtils.preventDefault(event);
-								return false;
-							}
+							eventUtils.preventDefault(event);
+							result = false;
 						}
 					}
 				}
-				return true;
+				return result;
 			}
 
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1238
[Problem] Router: Button with "data-rel='back'" & "href='#'"
  attributes causes loop on device Tizen 6.0
[Solution]
 - TAU had redundant action when click on link with "rel='back'".
  This caused duplicate popstate events and hashchange
  events. In most cases it doesn't matter but sometimes
  these events were in different order and this caused issue
  on device.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>