### PR TITLE
Slider: fix for min value option

### DIFF
--- a/examples/mobile/UIComponents/components/controllers/slider-level-bar.html
+++ b/examples/mobile/UIComponents/components/controllers/slider-level-bar.html
@@ -22,7 +22,7 @@
 		<div class="ui-content">
 			<div style="display: flex;">
 				<span style="font-size: 15px; padding: 7px 20px;">Level Bar</span>
-				<div style="flex: 1; padding-right: 20px;"><input max="7" min="0" type="range" value="3" data-type="level-bar"/></div>
+				<div style="flex: 1; padding-right: 20px;"><input max="9" min="2" type="range" value="3" data-type="level-bar"/></div>
 			</div>
 		</div>
 		<!-- /content -->

--- a/src/js/core/widget/core/Slider.js
+++ b/src/js/core/widget/core/Slider.js
@@ -368,7 +368,7 @@
 					percentValue;
 
 				// position of handle element
-				percentValue = value / (self._max - self._min) * 100;
+				percentValue = (value - self._min) / (self._max - self._min) * 100;
 				ui.beforeSpace.style["width"] = percentValue + "%";
 				ui.afterSpace.style["width"] = (100 - percentValue) + "%";
 				ui.valueElement.style["width"] = percentValue + "%";


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1244
[Problem] When slider option min != 0 then slider indicates
 wrong value
[Solution]
 Method for set widget value on UI has been changed

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>