### PR TITLE
Add theme changing option for all level 1 submenus

### DIFF
--- a/examples/mobile/UIComponents/components/appbar/index.html
+++ b/examples/mobile/UIComponents/components/appbar/index.html
@@ -18,6 +18,17 @@
 			<h1>
 				App Bar
 			</h1>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
+			</div>
 		</div>
 		<div class="ui-content">
 			<ul class="ui-listview ui-content-area">
@@ -54,6 +65,7 @@
 			</ul>
 		</div>
 	</div>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/components/buttons/index.html
+++ b/examples/mobile/UIComponents/components/buttons/index.html
@@ -18,6 +18,17 @@
 			<h1>
 				Buttons
 			</h1>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
+			</div>
 		</div>
 		<div class="ui-content">
 			<ul class="ui-listview ui-content-area">
@@ -34,6 +45,7 @@
 			</ul>
 		</div>
 	</div>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/components/controllers/index.html
+++ b/examples/mobile/UIComponents/components/controllers/index.html
@@ -18,6 +18,17 @@
 			<h1>
 				Controllers
 			</h1>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
+			</div>
 		</header>
 		<div class="ui-content">
 			<ul class="ui-listview ui-content-area">
@@ -64,6 +75,7 @@
 			</ul>
 		</div>
 	</div>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/components/dialogs/index.html
+++ b/examples/mobile/UIComponents/components/dialogs/index.html
@@ -18,6 +18,17 @@
 			<h1>
 				Dialogs
 			</h1>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
+			</div>
 		</div>
 		<div class="ui-content">
 			<ul class="ui-listview ui-content-area">
@@ -34,6 +45,7 @@
 			</ul>
 		</div>
 	</div>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/components/dividers/index.html
+++ b/examples/mobile/UIComponents/components/dividers/index.html
@@ -20,6 +20,14 @@
 			</div>
 			<div class="ui-appbar-action-buttons-container">
 				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
 			</div>
 		</header>
 		<div class="ui-content">
@@ -42,6 +50,7 @@
 			</ul>
 		</div>
 	</div>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/components/etc/index.html
+++ b/examples/mobile/UIComponents/components/etc/index.html
@@ -18,6 +18,17 @@
 			<h1>
 				Etc
 			</h1>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
+			</div>
 		</header>
 		<div class="ui-content">
 			<ul class="ui-listview ui-content-area">
@@ -49,8 +60,7 @@
 			</ul>
 		</div>
 	</div>
-	<script src="../../js/app.js">
-	</script>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/components/list/index.html
+++ b/examples/mobile/UIComponents/components/list/index.html
@@ -20,6 +20,14 @@
 			</div>
 			<div class="ui-appbar-action-buttons-container">
 				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
 			</div>
 		</header>
 		<div class="ui-content">
@@ -67,6 +75,7 @@
 			</ul>
 		</div>
 	</div>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/components/progress/index.html
+++ b/examples/mobile/UIComponents/components/progress/index.html
@@ -16,6 +16,17 @@
 			<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
 		</div>
 		<h1>Progress</h1>
+		<div class="ui-appbar-action-buttons-container">
+			<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+			<select class="theme-changer" data-native-menu="false" style="display: none">
+				<option value="light">
+					Light Theme
+				</option>
+				<option value="dark" class="ui-dropdown-two-lines">
+					Dark Theme
+				</option>
+			</select>
+		</div>
 	</header>
 	<div class="ui-content">
 		<ul class="ui-listview ui-content-area">
@@ -34,5 +45,6 @@
 		</ul>
 	</div>
 </div>
+<script src="../../js/app.js"></script>
 </body>
 </html>

--- a/examples/mobile/UIComponents/components/textfields/index.html
+++ b/examples/mobile/UIComponents/components/textfields/index.html
@@ -15,6 +15,17 @@
 			<h1>
 				Text fields
 			</h1>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
+			</div>
 		</header>
 		<div class="ui-content">
 			<ul class="ui-listview ui-content-area">
@@ -26,6 +37,7 @@
 			</ul>
 		</div>
 	</div>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/components/toast/index.html
+++ b/examples/mobile/UIComponents/components/toast/index.html
@@ -15,6 +15,17 @@
 			<h1>
 				Toast
 			</h1>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
+			</div>
 		</div>
 		<div data-role="content">
 			<ul class="ui-listview ui-content-area">
@@ -44,6 +55,7 @@
 			</div>
 		</div>
 	</div>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/components/view-controls/index.html
+++ b/examples/mobile/UIComponents/components/view-controls/index.html
@@ -18,6 +18,17 @@
 			<div class="ui-appbar-title-container">
 				<span class="ui-appbar-title">View controls</span>
 			</div>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
+			</div>
 		</header>
 		<div class="ui-content">
 			<ul class="ui-listview ui-content-area">
@@ -39,6 +50,7 @@
 			</ul>
 		</div>
 	</div>
+	<script src="../../js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/index.html
+++ b/examples/mobile/UIComponents/index.html
@@ -19,8 +19,8 @@
 				<span class="ui-appbar-title">UIComponents</span>
 			</div>
 			<div class="ui-appbar-action-buttons-container">
-				<button class="ui-btn ui-btn-icon ui-btn-icon-more" id="selector-opener" data-style="flat"></button>
-				<select data-native-menu="false" id="theme-selector" style="display: none">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
 					<option value="light">
 						Light Theme
 					</option>
@@ -90,8 +90,7 @@
 			</ul>
 		</div>
 	</div>
-	<script src="js/app.js">
-	</script>
+	<script src="js/app.js"></script>
 </body>
 
 </html>

--- a/examples/mobile/UIComponents/js/app.js
+++ b/examples/mobile/UIComponents/js/app.js
@@ -2,8 +2,9 @@
 
 (function () {
 
-	var themeChanger = document.querySelector("#theme-selector"),
-		themeChangerButton = document.querySelector("#selector-opener");
+	var themeChanger,
+		themeChangerButton,
+		themeChangerWidget;
 
 	window.addEventListener("tizenhwkey", function (ev) {
 		var activePopup = null,
@@ -36,14 +37,31 @@
 		dropDownMenuWidget.open();
 	}
 
-	document.addEventListener("pagebeforeshow", function () {
-		themeChanger.addEventListener("change", onMenuChange);
-		themeChangerButton.addEventListener("click", onMenuClick);
-	});
+	function onPageShow() {
+		themeChanger = document.querySelector(".ui-page-active .theme-changer"),
+		themeChangerButton = document.querySelector(".ui-page-active .ui-btn-icon-more");
 
-	document.addEventListener("pagebeforehide", function () {
-		themeChanger.removeEventListener("change", onMenuChange);
-		themeChangerButton.removeEventListener("click", onMenuClick);
-	});
+		if (themeChanger && themeChangerButton) {
+			themeChanger.value = tau.theme.getTheme();
+			themeChanger.addEventListener("change", onMenuChange);
+			themeChangerWidget = tau.engine.getBinding(themeChanger);
+			themeChangerWidget.refresh();
+		}
+		if (themeChangerButton) {
+			themeChangerButton.addEventListener("click", onMenuClick);
+		}
+	}
+
+	function onPageHide() {
+		if (themeChanger) {
+			themeChanger.removeEventListener("change", onMenuChange);
+		}
+		if (themeChangerButton) {
+			themeChangerButton.removeEventListener("click", onMenuClick);
+		}
+	}
+
+	document.addEventListener("pageshow", onPageShow);
+	document.addEventListener("pagehide", onPageHide);
 
 }());


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1165
[Problem] No theme change option
[Solution] Modify current theme changing mechanism to recognise widget from active page.
Add option for submenus.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>