### PR TITLE
Load only the length of the item

### DIFF
--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -1845,8 +1845,12 @@
 				var len = this._items.length,
 					i = 0;
 
-				for (i = 0; i < count; i++) {
-					this.addItem("", i + len);
+				for (i = len; i < len + count; i++) {
+					if (i >= this.options.dataLength) {
+						break;
+					}
+
+					this.addItem("", i);
 				}
 			}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1236
[Problem] Refer to the index that is more than the length of the data
[Solution] Check the length of the data when loading items

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>