### PR TITLE
Remove items when destroying the widget

### DIFF
--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -1782,11 +1782,6 @@
 					marqueeWidget = null;
 
 				self._unbindEvents();
-
-				self._items.forEach(function (li) {
-					self.element.appendChild(li);
-					li.setAttribute("style", "");
-				});
 				self._items = [];
 
 				// Destroy marquee.


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1249
[Problem] Even though the widget was destroied, items remained
[Solution] Prevent to append items to the element

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>