### PR TITLE
Add default schedule elements.

### DIFF
--- a/examples/mobile/ScheduleApp/js/app.js
+++ b/examples/mobile/ScheduleApp/js/app.js
@@ -8,6 +8,7 @@
 		defaultStore = [{
 			on: tempDate.getTime(),
 			off: tempDate.getTime() + 3900 * 1000, // + 1h 5m
+			type: "onoff",
 			dayOfWeek: [1, 2, 3]
 		}],
 		prototype = App.prototype,


### PR DESCRIPTION
[Issue] #1248
[Problem] - Default elements don't have type parameter
[Solution] - Add type parameter to defaultStore

Signed-off-by: Kornelia Kobiela <korneliak.95@gmail.com>