### PR TITLE
Initialize the position of the scroller when opening the page

### DIFF
--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -1704,6 +1704,9 @@
 
 
 				if (scroller) {
+					// initialize the position of the scroller
+					scroller.scrollTop = 0;
+
 					// disable tau rotaryScroller the widget has own support for rotary event
 					ns.util.rotaryScrolling && ns.util.rotaryScrolling.lock();
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1257
[Problem] Set the wrong max height of the scroll because of the scroller.scrollTop
[Solution] Initialize the scrollTop when initializing the page

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>