### PR TITLE
(mobile) Tabs: rounded mask for tabs content

### DIFF
--- a/src/css/profile/mobile/common/tabs.less
+++ b/src/css/profile/mobile/common/tabs.less
@@ -3,6 +3,9 @@
 	height: 100%;
 	overflow: hidden;
 
+	border-bottom-left-radius: 26 * @px_base;
+	border-bottom-right-radius: 26 * @px_base;
+
 	.ui-listview {
 		overflow: hidden;
 		min-height: 100%;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1157
[Problem] Sub Tab masking issue
[Solution]
 - Border radius has been added to tabs content

[Demo]
![obraz](https://user-images.githubusercontent.com/29534410/86588899-e23a0000-bf8c-11ea-9003-d9c61c82672a.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>