### PR TITLE
DropDownMenu: Fix for widget postion in AppBar

### DIFF
--- a/src/css/profile/mobile/common/dropdownmenu.less
+++ b/src/css/profile/mobile/common/dropdownmenu.less
@@ -95,6 +95,10 @@
 	}
 }
 
+.ui-dropdownmenu-force-display {
+	display: block !important;
+}
+
 .ui-dropdownmenu-native {
 	select {
 		display: block;
@@ -297,4 +301,11 @@
 
 .ui-li-static.ui-li-has-dropdownmenu {
 	height: 60 * @px_base;
+}
+
+.ui-appbar .ui-dropdownmenu-placeholder {
+	line-height: 56 * @px_base;
+}
+.ui-appbar-expanded .ui-dropdownmenu-placeholder {
+	line-height: (56 + 3) * @px_base; // compensate top margin
 }

--- a/src/js/profile/mobile/widget/DropdownMenu.js
+++ b/src/js/profile/mobile/widget/DropdownMenu.js
@@ -605,7 +605,7 @@
 			 * @static
 			 * @param {HTMLElement} element
 			 * @param {HTMLElement} container
-			 * @return number
+			 * @return {number}
 			 * @member ns.widget.mobile.DropdownMenu
 			 */
 			function getTopOffsetOfElement(element, container) {
@@ -1000,7 +1000,7 @@
 					elOptionContainer.addEventListener("focusin", self._focusBound); // bubble
 					elOptionContainer.addEventListener("focusout", self._blurBound); // bubble
 					if (ui.screenFilter) {
-						ui.screenFilter.addEventListener("vclick", self._toggleMenuBound);
+						ui.screenFilter.addEventListener("vmousedown", self._toggleMenuBound);
 					}
 					window.addEventListener("throttledresize", self._onResizeBound, true);
 				} else {
@@ -1040,7 +1040,9 @@
 					hiddenPart = 0, // hidden part of selected list element
 					maxContainerWidth;
 
+				ui.elSelectWrapper.classList.add("ui-dropdownmenu-force-display");
 				self._offsetTop = getTopOffsetOfElement(ui.elSelectWrapper, ui.page);
+				ui.elSelectWrapper.classList.remove("ui-dropdownmenu-force-display");
 				areaInfo = self._chooseDirection();
 
 				width = Math.max(biggestListItemWidth, wrapperMinWidth);
@@ -1105,6 +1107,7 @@
 						topArea: 0,
 						direction: ""
 					};
+
 				areaInfo.belowArea = ui.page.offsetHeight - self._offsetTop - ui.elPlaceHolder.offsetHeight + ui.content.scrollTop;
 				areaInfo.topArea = self._offsetTop - ui.content.scrollTop;
 
@@ -1330,7 +1333,7 @@
 					elOptionContainer.removeEventListener("focusout", self._blurBound);
 					ui.elOptionWrapper.parentNode.removeChild(ui.elOptionWrapper);
 					if (screenFilter) {
-						screenFilter.removeEventListener("vclick", self._toggleMenuBound);
+						screenFilter.removeEventListener("vmousedown", self._toggleMenuBound);
 						screenFilter.parentNode.removeChild(screenFilter);
 					}
 					window.removeEventListener("throttledresize", self._onResizeBound, true);


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1160
[Problem] More option position is wrong when AppBar is extended
[Solution]
 - height of Dropdown Menu placeholder in AppBar has changed to 56px
   because AppBar max height is 56px
 - DropDown Menu placeholder has to be visible during calculation of
   top position
 - Top margin of Menu when AppBar is extended should 0

[Demo]
Normal AppBar
![image](https://user-images.githubusercontent.com/29534410/86768492-f5f96b00-c04d-11ea-9eb3-7e3c044f95ae.png)

Extended AppBar
![image](https://user-images.githubusercontent.com/29534410/86768418-d3ffe880-c04d-11ea-8336-17eda1a70dd5.png)




Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>