### PR TITLE
HomeTV App: disabled pull to refresh

### DIFF
--- a/examples/mobile/HomeApp/css/style.css
+++ b/examples/mobile/HomeApp/css/style.css
@@ -42,3 +42,8 @@
     -webkit-mask-image: url(../images/Hamburger_icon.svg);
     mask-image: url(../images/Hamburger_icon.svg);
 }
+
+body {
+    /*disable-pull-to-refresh-effect*/
+    overscroll-behavior: contain;
+}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1271
[Problem] Pull down on appbar refresh the app
[Solution]
 - disbaled pull to refresh in css styles

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>