### PR TITLE
Flat Button: fix for wrong color of ripple effect in dark theme

### DIFF
--- a/src/css/profile/mobile/base.less
+++ b/src/css/profile/mobile/base.less
@@ -63,7 +63,7 @@
 @on-off-switch-off-track-background: transparent;
 @button-background-opacity: 6%;
 @button-background: fade(@_black, 0%);
-@button-flat-icon-background: #f5f5f5;
+@button-flat-icon-background: transparent;
 @button-background-contained: fade(@_black, @button-background-opacity);
 @button-text-font-size: 17 * @px_base;
 @button-contained-text-font-size: 17 * @px_base;

--- a/src/css/profile/mobile/common/button.less
+++ b/src/css/profile/mobile/common/button.less
@@ -419,7 +419,6 @@ a.ui-btn {
 				width: 56 * @px_base;
 				border-radius: 28 * @px_base;
 				background-color: var(--button-background-flat);
-				opacity: 1;
 			}
 			&-top {
 				line-height: normal;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1208
[Problem] The Ripple effect color is not consistent in Dark Mode
[Solution]
 - Background color for flat button with icon had deprecated color

[Demo]
![flat-icon-press](https://user-images.githubusercontent.com/29534410/86782672-ab80ea00-c05f-11ea-9e22-cd8ab149f9f8.gif)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>