### PR TITLE
Ensure that karma test coverage will not fall below current coverage

### DIFF
--- a/tests/karma/all.conf.js
+++ b/tests/karma/all.conf.js
@@ -24,7 +24,12 @@ module.exports = function (config) {
 				{ type: "clover", subdir: "clover" },
 				{ type: "lcov", subdir: "lcov" },
 				{ type: "text"}
-			]
+			],
+			check: {
+				global: {
+					lines: 53.96
+				}
+			}
 		},
 
 		// the default configuration


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1278
[Problem] Test coverage may decrease when adding new code
[Solution] Ensure that Karma fails when lines coverage is dropping below current one.
This should cause CI to fail too.
Current coverage is 53.96

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>