### PR TITLE
Set light and dark theme for weather widget

### DIFF
--- a/examples/mobile/HomeApp/index.html
+++ b/examples/mobile/HomeApp/index.html
@@ -38,10 +38,7 @@
 				Weather Forecast
 			</div>
 			<div class="ui-content-area">
-				<a style="border-radius: 26px" class="weatherwidget-io" href="https://forecast7.com/en/37d57126d98/seoul/" data-label_1="Seoul" data-label_2="South Korea" data-theme="original" >Seoul South Korea</a>
-				<script>
-					!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src='https://weatherwidget.io/js/widget.min.js';fjs.parentNode.insertBefore(js,fjs);}}(document,'script','weatherwidget-io-js');
-				</script>
+				<a style="border-radius: 26px" class="weatherwidget-io" href="https://forecast7.com/en/37d57126d98/seoul/" data-label_1="Seoul" data-label_2="South Korea" data-theme="pure" >Seoul South Korea</a>
 			</div>
 			<div class="ui-content-subheader">
 				Apps on TV

--- a/examples/mobile/HomeApp/js/app.js
+++ b/examples/mobile/HomeApp/js/app.js
@@ -24,8 +24,29 @@
 		nowOnTv.classList.toggle("app-display-none", !state.widgets.nowontv);
 	}
 
+	function loadWeatherJS() {
+		var head = document.getElementsByTagName("head")[0],
+			jsScript = document.getElementById("weatherwidget-io-js");
+
+		if (jsScript) {
+			jsScript.remove();
+		}
+		jsScript = document.createElement("script")
+		jsScript.src = "https://weatherwidget.io/js/widget.min.js";
+		jsScript.id = "weatherwidget-io-js";
+		head.appendChild(jsScript);
+	}
+
 	function changeTheme(event) {
+		var weatherWidget = document.querySelector(".weatherwidget-io");
+
 		tau.theme.setTheme(event.target.value);
+		if (event.target.value == "light") {
+			weatherWidget.setAttribute("data-theme", "pure");
+		} else {
+			weatherWidget.setAttribute("data-theme", "dark");
+		}
+		loadWeatherJS();
 	}
 
 	function onPopupSubmit() {
@@ -61,6 +82,7 @@
 
 		burgerButton.addEventListener("click", onButtonClick);
 		popupButton.addEventListener("click", onPopupSubmit);
+		loadWeatherJS();
 	}
 
 	document.addEventListener("pagebeforeshow", init);


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1285
[Problem] When changing theme weathter widget stays the same
[Solution] Apply proper theme to weather widget reloading JS script.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>