### PR TITLE
MoreMenu: Correct dropdown position after scroll

### DIFF
--- a/src/js/profile/mobile/widget/DropdownMenu.js
+++ b/src/js/profile/mobile/widget/DropdownMenu.js
@@ -1076,7 +1076,7 @@
 					if (areaInfo.topArea < ui.elPlaceHolder.offsetHeight) {
 						hiddenPart = scrollTop % ui.elPlaceHolder.offsetHeight;
 					}
-					offsetTop = self._offsetTop - scrollTop;
+					offsetTop = (self._offsetTop - scrollTop) < 0 ? 0 : self._offsetTop - scrollTop;
 					ui.elOptionWrapper.classList.add(classes.bottom);
 				}
 				// take into account part of clicked list item which is partially hidden


### PR DESCRIPTION
[Issue] #1284
[Problem] Dropdown position is not correct when content scrolled
[Solution] - Add condition to checking if element isn't overflowed
out the screen

Signed-off-by: Kornelia Kobiela <korneliak.95@gmail.com>