### PR TITLE
List: remove depreceted images from css code

### DIFF
--- a/src/css/profile/mobile/themes/dark.variables.less
+++ b/src/css/profile/mobile/themes/dark.variables.less
@@ -66,7 +66,6 @@
 
     @expander-color: #808080;
     @spin-item-opacity: 0.2;
-    @expander-url: url('images/6_Lists/tw_expander_close_mtrl_alpha_dark.9.png');
     @calendar-weekend-color: #993d3d;
     @calendar-text-color: #cccccc;
     @calendar-arrow-color: #737373;

--- a/src/css/profile/mobile/themes/light.variables.less
+++ b/src/css/profile/mobile/themes/light.variables.less
@@ -64,7 +64,6 @@
 
     @expander-color: #747474;
     @spin-item-opacity: 0.1;
-    @expander-url: url('images/6_Lists/tw_expander_close_mtrl_alpha_light.9.png');
     @calendar-weekend-color: #d77e7e;
     @calendar-text-color: #454545;
     @calendar-arrow-color: #8e8e8e;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1183
[Problem] List: Image removed but still exists in implementation
 for expander
[Solution] Associations to these images can be safely removed.
 Verified.

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>