### PR TITLE
Util: added method "tau.throws()" and added tests for it

### DIFF
--- a/src/js/core/core.js
+++ b/src/js/core/core.js
@@ -41,7 +41,10 @@
 				args.unshift("[" + rootNamespace + "][" + dateNow.toLocaleString() + "]");
 			},
 			ns = window.ns || window.tau || {},
-			nsConfig = window.nsConfig || window.tauConfig || {};
+			nsConfig = window.nsConfig || window.tauConfig || {},
+			TAUException = function (message) {
+				this.message = message;
+			};
 
 		ns.info = ns.info || {
 			profile: "custom"
@@ -56,6 +59,10 @@
 
 		rootNamespace = nsConfig.rootNamespace;
 		fileName = nsConfig.fileName;
+
+		TAUException.prototype.toString = function () {
+			return this.message;
+		};
 
 		/**
 		 * Return unique id
@@ -177,6 +184,21 @@
 				}
 			}
 			return null;
+		};
+
+		ns._TAUException = TAUException;
+
+		/**
+		 * Method throws TAU exception with given message
+		 * @param {string} message
+		 * @method throws
+		 * @member ns
+		 */
+		ns.throws = function (message) {
+			if (typeof message !== "string") {
+				ns.throws("Wrong parameter type. Message must be a string!");
+			}
+			throw new ns._TAUException(message);
 		};
 
 		//>>excludeStart("tauBuildExclude", pragmas.tauBuildExclude);

--- a/src/js/core/util.js
+++ b/src/js/core/util.js
@@ -54,6 +54,9 @@
 			 * @protected
 			 */
 			util._requestAnimationFrameOnSetTimeout = function (callback) {
+				if (typeof callback !== "function") {
+					ns.throws("Parameter is not a function!");
+				}
 				currentFrame = window.setTimeout(callback.bind(callback, +new Date()), 1000 / 60);
 			};
 

--- a/tests/js/core/core/core.js
+++ b/tests/js/core/core/core.js
@@ -64,6 +64,25 @@ function runTests(tau, helpers) {
 		equal(tau.error("test1", "test2", "test3"), undefined, "Result of tau.error");
 		helpers.restoreStub(window.console, "error");
 	});
+
+	test("Method throws", 1, function (assert) {
+		assert.throws(function () {
+			tau.throws("Message");
+		}, function (e) {
+			return e instanceof tau._TAUException &&
+				e.toString() === "Message";
+		}, "Method throws exception with proper message");
+	});
+
+	test("Method throws [n]", 1, function (assert) {
+		assert.throws(function () {
+			// Method requires a string as parameter in other ways throws exception
+			tau.throws();
+		}, function (e) {
+			return e instanceof tau._TAUException &&
+				e.toString() === "Wrong parameter type. Message must be a string!";
+		}, "Parameter is not string");
+	});
 }
 
 if (typeof define === "function") {

--- a/tests/js/core/util/util.js
+++ b/tests/js/core/util/util.js
@@ -56,6 +56,16 @@
 			helpers.restoreStub(window, "setTimeout");
 		});
 
+		test("_requestAnimationFrameOnSetTimeout [n]", 1, function (assert) {
+			assert.throws(function () {
+				// Method requires a callback as parameter in other ways throws exception
+				util._requestAnimationFrameOnSetTimeout();
+			}, function (e) {
+				return e instanceof ns._TAUException &&
+					e.toString() === "Parameter is not a function!";
+			}, "Parameter is undefined");
+		});
+
 		test("_cancelAnimationFrameOnSetTimeout", 2, function () {
 			equal(typeof util._cancelAnimationFrameOnSetTimeout, "function", "_cancelAnimationFrameOnSetTimeout exists and is a method");
 

--- a/tests/karma/all.conf.js
+++ b/tests/karma/all.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
 			],
 			check: {
 				global: {
-					lines: 53.96
+					lines: 54
 				}
 			}
 		},


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1296
    [Problem] Add sample of negative TC for a widget
    [Solution]
     - added new TAU method "throws" which throws TAUException
     - added check if method throws exception in case of
     argument lack
     - added tests for core.throws with negative TC (nTC)
     - added nTC for util.requestAnimationFrame without callback

![obraz](https://user-images.githubusercontent.com/29534410/87276893-8669fc80-c4e1-11ea-81ef-d0d4437bb497.png)

![obraz](https://user-images.githubusercontent.com/29534410/87143380-479c3280-c2a6-11ea-9bde-f753006e564f.png)

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>