### PR TITLE
Fix sonar issue - wrong place of declaration

### DIFF
--- a/src/js/core/widget/core/Appbar.js
+++ b/src/js/core/widget/core/Appbar.js
@@ -41,6 +41,10 @@
 				Page = ns.widget.core.Page,
 				min = Math.min,
 				max = Math.max,
+				nominalHeights = {
+					COLLAPSED: 56,
+					EXPANDED: 56
+				},
 				states = {
 					EXPANDED: "EXPANDED",
 					COLLAPSED: "COLLAPSED",
@@ -85,10 +89,6 @@
 					selectAll: "ui-label-select-all",
 					bottomBar: "ui-bottom-bar",
 					hidden: "ui-hidden"
-				},
-				nominalHeights = {
-					COLLAPSED: 56,
-					EXPANDED: 56
 				},
 				containersProperties = {
 					leftIconsContainer: {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1295
[Problem] Sonar warning:
Move the declaration of "nominalHeights" before this usage.
[Solution] Moved the declaration to proper place

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>