### PR TITLE
Add orientationchange to Karma tests

### DIFF
--- a/tests/js/core/event/orientationchange/orientationchange.js
+++ b/tests/js/core/event/orientationchange/orientationchange.js
@@ -1,9 +1,7 @@
-/*global window, start */
-(function (window, document, tau, QUnit, define) {
+/* global QUnit, define, start, tau */
+(function () {
 	"use strict";
-
 	QUnit.config.reorder = false;
-
 	function runTests(orientation, helpers) {
 		var mockWindow = {
 				matchMedia: null,
@@ -27,10 +25,21 @@
 			},
 			originalSupport = false;
 
+		orientation = orientation || window.ns.event.orientationchange;
+		helpers = helpers || window.helpers;
+
+		function initHTML() {
+			var HTML = helpers.loadHTMLFromFile("/base/tests/js/core/event/orientationchange/test-data/sample.html"),
+				parent = document.getElementById("qunit-fixture") || helpers.initFixture();
+
+			parent.innerHTML = HTML;
+		}
+
 		QUnit.module("core/event/orientationchange", {
 			setup: function () {
 				orientation._window = mockWindow;
 				originalSupport = orientation.supported;
+				initHTML();
 			},
 			teardown: function () {
 				orientation._window = window;
@@ -174,18 +183,12 @@
 		});
 	}
 
-	if (define) {
-		define(
-			[
-				"../../../../../src/js/core/event/orientationchange",
-				"../../../../karma/tests/helpers"
-			],
-			function (engine, event, orientation, helpers) {
-				return runTests.bind(null, orientation, helpers);
-			}
-		);
+	if (typeof define === "function") {
+		define(function () {
+			return runTests;
+		});
 	} else {
-		runTests(tau.event.orientationchange, window.helpers);
+		runTests(tau.event.orientationchange, window.helpers)
 	}
 
-}(window, window.document, window.tau, window.QUnit, window.define));
+}());

--- a/tests/js/core/event/orientationchange/test-data/sample.html
+++ b/tests/js/core/event/orientationchange/test-data/sample.html
@@ -1,0 +1,3 @@
+<div data-role="page" id="first">
+    <div data-role="mock" id="mock1">Mock</div>
+</div>

--- a/tests/karma/single.test.path.js
+++ b/tests/karma/single.test.path.js
@@ -1,6 +1,6 @@
 /*global testPaths:true */
 testPaths = [
-	"core/widget/core/Drawer"
+	"core/event/orientationchange"
 ];
 
 // For test:

--- a/tests/karma/testPaths.js
+++ b/tests/karma/testPaths.js
@@ -55,6 +55,7 @@ testPaths = [
 	"core/event/gesture/LongPress",
 	"core/event/gesture/Pinch",
 	"core/event/gesture/Swipe",
+	"core/event/orientationchange",
 	"profile/wearable/router/route/grid",
 	"core/router/Router",
 	"core/widget/core/tab/SubTab",


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1313
[Problem] Orienattionchange line coverage is low
[Solution] Add orientationchange to Karma tests. Modify tests.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>