### PR TITLE
(test) Karma config: set minimal test coverage for lines to 60.48%

### DIFF
--- a/tests/karma/all.conf.js
+++ b/tests/karma/all.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
 			],
 			check: {
 				global: {
-					lines: 54
+					lines: 60.48
 				}
 			}
 		},


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1278
[Problem] Hold the Karma test coverage for lines above 60%
[Solution]
 - Karma config modification

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>