### PR TITLE
Fix bottom button in example

### DIFF
--- a/examples/mobile/UIComponents/components/buttons/contained/emphasis/medium-high-emphasis1.html
+++ b/examples/mobile/UIComponents/components/buttons/contained/emphasis/medium-high-emphasis1.html
@@ -58,7 +58,7 @@
 				</li>
 			</ul>
 		</div>
-		<footer>
+		<footer class="ui-bottom-button">
 			<button data-style="contained">
 				Radius : 22dp
 			</button>


### PR DESCRIPTION
[Issue] #1241
[Problem] Bottom buttons had no margins
[Solution] Add `ui-bottom-button` class to footer

Signed-off-by: Kornelia Kobiela <korneliak.95@gmail.com>