### PR TITLE
Expand Button: add examples in Controllers menu

### DIFF
--- a/examples/mobile/UIComponents/components/controllers/expand-button.html
+++ b/examples/mobile/UIComponents/components/controllers/expand-button.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Expand Button</title>
+	<meta content="width=device-width, user-scalable=no" name="viewport" />
+	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../css/style.css" rel="stylesheet" />
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	</script>
+</head>
+
+<body>
+	<div class="ui-page" id="slider-demo">
+		<div class="ui-header" data-position="fixed">
+			<div class="ui-appbar-left-icons-container">
+				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
+			</div>
+			<h1>
+				Expand button
+			</h1>
+		</div>
+		<div class="ui-content">
+			<ul class="ui-listview ui-content-area">
+				<li class="ui-li-anchor">
+					<a href="../list/expandable-list.html">
+						Expand button on list
+					</a>
+				</li>
+			</ul>
+		</div>
+		<!-- /content -->
+	</div>
+	<!-- /page -->
+</body>
+
+</html>

--- a/examples/mobile/UIComponents/components/controllers/index.html
+++ b/examples/mobile/UIComponents/components/controllers/index.html
@@ -72,6 +72,11 @@
 						Slider (Level bar)
 					</a>
 				</li>
+				<li class="ui-li-anchor">
+					<a href="expand-button.html">
+						Expand Button
+					</a>
+				</li>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1334
[Problem] Expandable button: List type - GUI needs verification
[Solution]
 - added menu to UIComponets > Controllers

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>