### PR TITLE
Recalculate the height of scroll when initializing the page

### DIFF
--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -394,6 +394,7 @@
 					diffY = null,
 					scroller = self._ui.scroller,
 					state = self._state,
+					elementHeight = 0,
 					parentElement,
 					parentClassList;
 
@@ -401,9 +402,7 @@
 					parentElement = self.element;
 					parentClassList = parentElement.classList;
 
-					// set parent size
 					parentRect = parentElement.getBoundingClientRect();
-					prepareParentStyle(parentElement, parentRect);
 
 					parentClassList.add(classes.FORCE_RELATIVE);
 
@@ -426,6 +425,7 @@
 							item.y = round(rect.top + rect.height / 2 + scroller.scrollTop);
 							item.height = rect.height;
 							item.rect = rect;
+							elementHeight += item.height;
 							if (diffY === null) {
 								diffY = rect.top - parentRect.top;
 							}
@@ -433,6 +433,11 @@
 					});
 
 					parentClassList.remove(classes.FORCE_RELATIVE);
+
+					// set parent size
+					prepareParentStyle(parentElement, {
+						height: elementHeight
+					});
 
 					arrayUtil.forEach(items, function (item) {
 						if (item.parentElement === parentElement) {

--- a/tests/js/profile/wearable/widget/wearable/ArcListview/ArcListview.js
+++ b/tests/js/profile/wearable/widget/wearable/ArcListview/ArcListview.js
@@ -340,7 +340,7 @@
 					assert.ok("Called function from flow");
 				};
 
-			expect(6);
+			expect(7);
 
 			helpers.stub(ArcListview, "calcFactors", function (a, b) {
 				assert.equal(a, listWidget.options.ellipsisA, "a was correct assign");
@@ -351,6 +351,7 @@
 			listWidget._setAnimatedItems = testStub;
 			listWidget._refresh = testStub;
 			listWidget._scroll = testStub;
+			listWidget._initBouncingEffect = testStub;
 			listWidget._ui.page = pageElement;
 
 			listWidget._init();
@@ -854,6 +855,24 @@
 			assert.equal(arclistWidget._state.toIndex, 0, "_state.toIndex is correct");
 			arclistWidget._rollUp();
 			assert.equal(arclistWidget._state.toIndex, 0, "_state.toIndex is correct");
+		});
+
+		QUnit.test("addItem", function (assert) {
+			var listWidget = new ArcListview(),
+				element = document.getElementById("arc-list"),
+				page = element.parentElement.parentElement.parentElement,
+				arcListviewCarousel = element.parentElement;
+
+			listWidget.element = element;
+			listWidget._ui.page = page;
+			listWidget._ui.arcListviewCarousel = arcListviewCarousel;
+			listWidget._init();
+
+			expect(2);
+
+			assert.equal(listWidget._state.items.length, 9, "_state.items.length is correct");
+			listWidget.addItem("added Item", 0);
+			assert.equal(listWidget._state.items.length, 10, "_state.items.length is correct");
 		});
 	}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1318
[Problem] Parent height isn't changed when opening the page
[Solution] Recalculated the parent height with sum of the heights of the items

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>