### PR TITLE
Add a config to enable the circular scrollbar

### DIFF
--- a/src/js/profile/wearable/config.js
+++ b/src/js/profile/wearable/config.js
@@ -39,6 +39,7 @@
 				ns.setConfig("popupFullSize", true, true);
 				ns.setConfig("scrollEndEffectArea", "screen", true);
 				ns.setConfig("enablePageScroll", true, true);
+				ns.setConfig("enableCircularScrollbar", true, true);
 				ns.setConfig("enablePopupScroll", true, true);
 			} else {
 				ns.setConfig("popupTransition", "slideup", true);

--- a/src/js/profile/wearable/widget/wearable/Scrollview.js
+++ b/src/js/profile/wearable/widget/wearable/Scrollview.js
@@ -140,7 +140,8 @@
 					children = [].slice.call(element.children),
 					scroller,
 					content,
-					fragment;
+					fragment,
+					enableCircularScrollbar;
 
 				element.classList.add(pageScrollSelector);
 				scroller = document.createElement("div");
@@ -162,11 +163,13 @@
 				scroller.appendChild(fragment);
 
 				if (ns.support.shape.circle) {
-					if (scroller) {
+					enableCircularScrollbar = ns.getConfig("enableCircularScrollbar");
+
+					if (scroller && enableCircularScrollbar) {
 						scroller.setAttribute(scrollBarType.CIRCLE, "");
 					}
 					content = element.querySelector("." + classes.uiContent);
-					if (content) {
+					if (content && enableCircularScrollbar) {
 						content.setAttribute(scrollBarType.CIRCLE, "");
 					}
 				}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1350
[Problem] There is a no option to hide the native circular
scrollbar in the wearable profile
[Solution] Add a config option to enble/disable circular scrollbar

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>