### PR TITLE
PageContainer: jqm test fails

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -622,7 +622,7 @@ module.exports = function (grunt) {
 			postcss: {
 				options: {
 					processors: [
-						autoprefixer({browsers: "last 10 Samsung versions, last 10 versions, last 10 ChromeAndroid versions"})
+						autoprefixer({browsers: "last 12 Samsung versions, last 12 versions, last 12 ChromeAndroid versions"})
 					]
 				},
 				dist: {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1379
[Problem] PageContainer test fails
[Solution]
 - Issue was referring to settings of postcss tool.
 Css generated by postcss wasn't supported by phantomJS

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>