### PR TITLE
HomeApp: correct path for weblicps

### DIFF
--- a/examples/mobile/HomeApp/js/app.js
+++ b/examples/mobile/HomeApp/js/app.js
@@ -104,6 +104,11 @@
 		activeWebClipList.forEach(function (webclip) {
 			var card = document.createElement("div");
 
+			// add slash for name of webClip
+			if (!webclip.match(/\/$/)) {
+				webclip += "/";
+			}
+
 			card.classList.add("ui-card");
 			card.setAttribute("data-src", webclip);
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1381
[Problem] HomeApp tries to load webclip direclty from url
[Solution]
 - fix: correction of path when path is not .html file or
 is not directory

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>