### PR TITLE
Omit files when listing webclip directory content

### DIFF
--- a/examples/mobile/HomeAppServer/app.js
+++ b/examples/mobile/HomeAppServer/app.js
@@ -20,7 +20,13 @@ app.get("/api/webcliplist", (req, res) => {
 
 		if (!err) {
 			files.forEach((file) => {
-				result.push(webClipDir + "/" + file)
+				try {
+					if (fs.lstatSync(homeAppPath + "/" + webClipDir + "/" + file).isDirectory()) {
+						result.push(webClipDir + "/" + file)
+					}
+				} catch (e) {
+					// unable to figure out if element is directory or not
+				}
 			});
 		}
 		res.header("Content-Type", "application/json");


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1384
[Problem] Server API for webclip list returns both files and directories
[Solution] Use fs.lstatSync(path_string).isDirectory() in order to distinguish
directories as suggested in [1]

[1] - https://stackoverflow.com/questions/15630770/node-js-check-if-path-is-file-or-directory#15630832

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>