### PR TITLE
Load weather JS from Weather WebClip

### DIFF
--- a/examples/mobile/HomeApp/js/app.js
+++ b/examples/mobile/HomeApp/js/app.js
@@ -9,29 +9,8 @@
 			"webclip/weather"
 		];
 
-	function loadWeatherJS() {
-		var head = document.getElementsByTagName("head")[0],
-			jsScript = document.getElementById("weatherwidget-io-js");
-
-		if (jsScript) {
-			jsScript.remove();
-		}
-		jsScript = document.createElement("script")
-		jsScript.src = "https://weatherwidget.io/js/widget.min.js";
-		jsScript.id = "weatherwidget-io-js";
-		head.appendChild(jsScript);
-	}
-
 	function changeTheme(event) {
-		var weatherWidget = document.querySelector(".weatherwidget-io");
-
 		tau.theme.setTheme(event.target.value);
-		if (event.target.value == "light") {
-			weatherWidget.setAttribute("data-theme", "pure");
-		} else {
-			weatherWidget.setAttribute("data-theme", "dark");
-		}
-		loadWeatherJS();
 	}
 
 	function loadWebClipList() {
@@ -188,7 +167,6 @@
 		burgerButton.addEventListener("click", onButtonClick);
 		popupButton.addEventListener("click", onPopupSubmit);
 
-		loadWeatherJS();
 		loadWebClipList();
 	}
 

--- a/examples/mobile/HomeApp/webclip/weather/js/app.js
+++ b/examples/mobile/HomeApp/webclip/weather/js/app.js
@@ -14,9 +14,21 @@
 		head.appendChild(jsScript);
 	}
 
+	function changeTheme(event) {
+		var weatherWidget = document.querySelector(".weatherwidget-io");
+
+		if (event.detail.theme === "light") {
+			weatherWidget.setAttribute("data-theme", "pure");
+		} else {
+			weatherWidget.setAttribute("data-theme", "dark");
+		}
+		loadWeatherJS();
+	}
+
 	function init() {
 		loadWeatherJS();
 	}
 
-	document.addEventListener("pagebeforeshow", init);
+	document.addEventListener("cardcontentchange", init);
+	document.addEventListener("themechange", changeTheme);
 }());

--- a/examples/mobile/HomeApp/webclip/weather/webclip.html
+++ b/examples/mobile/HomeApp/webclip/weather/webclip.html
@@ -1,5 +1,6 @@
 <div class="ui-card app-weather-container">
 	<link rel="stylesheet" href="css/style.css" />
+	<script src="js/app.js"></script>
 	<div class="ui-content-subheader">
 		Weather Forecast
 	</div>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1390
[Problem] JS for Weather WebClip is not loaded form WebClip but form main app
[Solution] Move loading to WebClip code. Add loading JS when cardcontentchange or themechange
events occur.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>