### PR TITLE
Improve active WebClip list checking

### DIFF
--- a/examples/mobile/HomeApp/js/app.js
+++ b/examples/mobile/HomeApp/js/app.js
@@ -20,12 +20,6 @@
 			.then((response) => response.json())
 			.then((data) => {
 				webClipList = data;
-				// make sure that default active webclip list contains only available elements
-				activeWebClipList.forEach(function (webclip) {
-					if (!webClipList.includes(webclip)) {
-						activeWebClipList.splice(activeWebClipList.indexOf(webclip), 1);
-					}
-				})
 			})
 			.catch(() => {
 				// use default webclip list is sth wrong
@@ -40,6 +34,10 @@
 					]
 			})
 			.finally(() => {
+				// make sure that default active webclip list contains only available elements
+				activeWebClipList = activeWebClipList.filter(function (webClip) {
+					return webClipList.includes(webClip);
+				})
 				updateWebClipsUI();
 				updateWebClipListPopup();
 			});


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1406
[Problem] Active WebClip list is not checked properly
[Solution] Check active WebClip list regardless REST API succeeds or not.
Enumerate using shallow copy not current table which is being modified during
enumeration.

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>