### PR TITLE
Drawer: change widget width on TV resolution

### DIFF
--- a/src/js/profile/mobile/widget/Drawer.js
+++ b/src/js/profile/mobile/widget/Drawer.js
@@ -62,7 +62,8 @@
 				 */
 
 				self.options.dragEdge = 0.05;
-				self.options.width = 0.75 * window.screen.width;
+				self.options.width = (window.screen.width >= 960) ? 360 : // for TV HD+
+					0.75 * window.screen.width; // mobile
 				self.options.height = window.screen.height;
 			};
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1426
[Problem] Drawer: right space is too big on TV
[Solution]
 - widget width for big screen is fixed to 360px

[Screenshot]
![obraz](https://user-images.githubusercontent.com/29534410/93745059-2c796780-fbf3-11ea-97f6-7cd1b1389d5d.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>