### PR TITLE
AppBar: fix for disable Appbar expanding

### DIFF
--- a/examples/mobile/HomeApp/index.html
+++ b/examples/mobile/HomeApp/index.html
@@ -14,7 +14,7 @@
 </head>
 <body>
 	<div class="ui-page ui-page-active" id="main">
-		<header>
+		<header data-expanding-enabled="false">
 			<div class="ui-appbar-title-container">
 				<span class="ui-appbar-title">HomeTV App</span>
 			</div>

--- a/src/js/core/widget/core/Appbar.js
+++ b/src/js/core/widget/core/Appbar.js
@@ -555,9 +555,9 @@
 				var self = this;
 
 				if (window.screen.height <= SCREEN_HEIGHT_LIMIT_FOR_EXPANDING) {
-					self.option("expandingEnabled", false);
+					self._lockExpanding = true;
 				} else {
-					self.option("expandingEnabled", true);
+					self._lockExpanding = false;
 				}
 			}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1428
[Problem] AppBar: option `data-expanding-enabled="false"`
 doesn't work on widget init
[Solution]
 - modification of method for lock the widget expanding
 - HomeTV app - disable appbar expanding

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>