### PR TITLE
Allow to configure WWW and socket ports

### DIFF
--- a/examples/mobile/HomeAppServer/app.js
+++ b/examples/mobile/HomeAppServer/app.js
@@ -1,12 +1,14 @@
 const homeAppPath = "../HomeApp";
 const WebSocket = require("ws");
 
-var express = require("express");
+var express = require("express"),
+	socketPort = process.env.PORT_SOCKET || 0;
 var path = require("path");
 var cookieParser = require("cookie-parser");
 var logger = require("morgan"),
 	app = express(),
 	ws,
+	wsPort,
 	pingCount = 0,
 	result = {},
 	apps = [{
@@ -55,8 +57,9 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use("/", express.static(path.join(__dirname, homeAppPath)));
 
+wsPort = startWS();
+
 app.get("/api/register", (req, res) => {
-	const wsPort = startWS();
 
 	result.apps = apps;
 	result.wsPort = wsPort;
@@ -74,7 +77,7 @@ function runPing(ws) {
 				apps: apps
 			}));
 		} catch (e) {
-			console.warn("ws error");
+			console.warn("setInterval: " + e.message);
 		}
 
 		// @test
@@ -109,7 +112,7 @@ function onWSConnection(ws) {
 }
 
 function startWS() {
-	var server = app.listen(0);
+	var server = app.listen(socketPort);
 
 	ws = new WebSocket.Server({server});
 	ws.on("connection", onWSConnection);

--- a/examples/mobile/HomeAppServer/bin/www
+++ b/examples/mobile/HomeAppServer/bin/www
@@ -11,8 +11,7 @@ var http = require('http');
 /**
  * Get port from environment and store in Express.
  */
-
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(process.env.PORT_WWW || '3000');
 app.set('port', port);
 
 /**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1450
[Problem] In dev env. some ports are blocked so websocket connection doesn't work
[Solution] Allow to configure sockets and www ports with env variables: PORT_SOCKET and PORT_WWW

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>