### PR TITLE
(engine) Remove deprecated log referring to destroy widgets

### DIFF
--- a/src/js/core/engine.js
+++ b/src/js/core/engine.js
@@ -755,10 +755,6 @@
 					element = document.getElementById(element);
 				}
 
-				//>>excludeStart("tauDebug", pragmas.tauDebug);
-				ns.log("Removing all widgets for element:", element);
-				//>>excludeEnd("tauDebug");
-
 				// If type is not defined all widgets should be removed
 				// this is for backward compatibility
 				widgetInstance = getBinding(element, type);
@@ -815,10 +811,6 @@
 				if (typeof element === TYPE_STRING) {
 					element = document.getElementById(element);
 				}
-
-				//>>excludeStart("tauDebug", pragmas.tauDebug);
-				ns.log("Removing all widgets for element:", element);
-				//>>excludeEnd("tauDebug");
 
 				if (!childOnly) {
 					// If type is not defined all widgets should be removed


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1460
[Problem] Remove depraced TAU log from engine module
[Solution]
 - debug log has been removed

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>