### PR TITLE
HomeApp: add mini control card in runtime

### DIFF
--- a/examples/mobile/HomeApp/index.html
+++ b/examples/mobile/HomeApp/index.html
@@ -37,15 +37,8 @@
 				<div class="ui-icon">
 					<img src="images/icon.png"/>
 				</div>
-				<span class="ui-title">Control card 1</span>
-				<a href="#open-control-app-1" class="ui-btn" styl="flat" data-inline="true" data-icon="next"></a>
-			</div>
-			<div class="ui-appbar-container ui-content-area">
-				<div class="ui-icon">
-					<img src="images/icon.png"/>
-				</div>
-				<span class="ui-title">Control card 2</span>
-				<a href="#open-control-app-2" class="ui-btn" styl="flat" data-inline="true" data-icon="next"></a>
+				<span class="ui-title">Generic control</span>
+				<a href="#open-control-app-1" class="ui-btn" data-style="flat" data-inline="true" data-icon="next"></a>
 			</div>
 		</header>
 		<div class="ui-content">

--- a/src/js/core/widget/core/Appbar.js
+++ b/src/js/core/widget/core/Appbar.js
@@ -157,19 +157,9 @@
 				return element;
 			};
 
-			/**
-			 * Method set new height of appbar if instant container exists
-			 * @param {HTMLElement} element
-			 * @method _findInstantContainers
-			 * @member ns.widget.core.Appbar
-			 * @protected
-			 */
-			prototype._findInstantContainers = function (element) {
+			prototype._calculateInstantContainers = function (element) {
 				var self = this,
-					instantContainersHeight = 0,
-					controlsContainer = self._ui.controlsContainer;
-
-				self._ui.instantContainers = [].slice.call(element.querySelectorAll("." + classes.instantContainer));
+					instantContainersHeight = 0;
 
 				// calculate instant containers height
 				element.style.height = "auto";
@@ -177,8 +167,17 @@
 					instantContainersHeight += container.offsetHeight;
 				});
 
+				return instantContainersHeight;
+			};
+
+			prototype._updateAppbarDimensions = function (element) {
+				var self = this,
+					instantContainersHeight = self._instantContainersHeight,
+					controlsContainer = self._ui.controlsContainer;
+
 				// increase height of appbar and change bottom possition of control container
 				if (instantContainersHeight > 0) {
+					self._calculateExtendedHight();
 					self._expandedHeight += instantContainersHeight;
 					self._currentHeight += instantContainersHeight;
 					if (controlsContainer) {
@@ -192,15 +191,75 @@
 			};
 
 			/**
+			 * Method set new height of appbar if instant container exists
+			 * @param {HTMLElement} element
+			 * @method _findInstantContainers
+			 * @member ns.widget.core.Appbar
+			 * @protected
+			 */
+			prototype._findInstantContainers = function (element) {
+				var self = this;
+
+				self._ui.instantContainers = [].slice.call(element.querySelectorAll("." + classes.instantContainer));
+
+				self._instantContainersHeight = self._calculateInstantContainers(element);
+				self._updateAppbarDimensions(element);
+			};
+
+			/**
+			 * Add Html element as instant container
+			 * @param {HTMLElement} container
+			 * @method addInstantContainer
+			 * @member ns.widget.core.Appbar
+			 * @protected
+			 */
+			prototype.addInstantContainer = function (container) {
+				var self = this;
+
+				if (container && container instanceof HTMLElement) {
+					container.classList.add(classes.instantContainer);
+					self.element.appendChild(container);
+					self.refresh();
+				} else {
+					ns.warn("AppBar: method addInstantContainer needs argument");
+				}
+			}
+
+			/**
+			 * Remove instant container
+			 * @param {HTMLElement} container
+			 * @method removeInstantContainer
+			 * @member ns.widget.core.Appbar
+			 * @protected
+			 */
+			prototype.removeInstantContainer = function (container) {
+				var self = this;
+
+				if (container && container instanceof HTMLElement) {
+					if (container.parentElement) {
+						container.parentElement.removeChild(container);
+						self.refresh();
+					}
+				} else {
+					ns.warn("AppBar: method removeInstantContainer needs argument");
+				}
+			}
+
+			/**
 			 * Refresh the widget
 			 * @method _refresh
 			 * @member ns.widget.core.Appbar
+			 * @param {HTMLElement} element
 			 * @protected
 			 */
 			prototype._refresh = function (element) {
 				var self = this;
 
-				self._setLineType(element);
+				element = element || self.element;
+				self._findInstantContainers(element);
+				self._ui.instantContainers.forEach(function (container) {
+					ns.engine.createWidgets(container);
+				});
 			};
 
 			/**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1466
[Problem] HomeApp requires add/delete mini control in runtime
[Solution]
 - add example
 - add implementation to TAU AppBar

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>