### PR TITLE
Fix title position in ads card

### DIFF
--- a/src/css/profile/mobile/common/card.less
+++ b/src/css/profile/mobile/common/card.less
@@ -197,7 +197,7 @@
 				color: var(--text-color);
 				font-size: 16 * @sp_base;
 				white-space: normal;
-				margin: 0 20 * @px_base;
+				margin: 0 20 * @px_base 0 0;
 				flex: 1;
 				text-align: left;
 			}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1459
[Problem] Title position in second ads card is not properly positioned
[Solution] Override padding-left property for ui-footer

Signed-off-by: Lukasz Slachciak <l.slachciak@samsung.com>