### PR TITLE
Card: content of card loaded from data-src is appending to card element

### DIFF
--- a/src/js/core/widget/core/Card.js
+++ b/src/js/core/widget/core/Card.js
@@ -164,7 +164,6 @@
 
 				if (self.element.parentElement) {
 					content = self._include(content, options);
-					self.element.parentElement.replaceChild(content, self.element);
 					ns.engine.createWidgets(content);
 					eventUtils.trigger(content, "cardcontentchange");
 				} else {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1484
[Problem] Card with data-src attribute should be append to widget
 element instead of replace it
[Solution]
 - method for update content of card has been changed

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>