### PR TITLE
HomeApp: stop scrolling on interaction with touchpad area

### DIFF
--- a/examples/mobile/HomeApp/control.html
+++ b/examples/mobile/HomeApp/control.html
@@ -14,6 +14,7 @@
 </head>
 <body>
 	<div class="ui-page" id="open-control-app-1">
+		<script src="js/control.js"></script>
 		<header>
 			<div class="ui-appbar-title-container">
 				<span class="ui-appbar-title">Instant Control</span>

--- a/examples/mobile/HomeApp/js/control.js
+++ b/examples/mobile/HomeApp/js/control.js
@@ -1,0 +1,21 @@
+/* global tau */
+(function () {
+	var page = document.getElementById("open-control-app-1"),
+		onpagebeforeshow = function () {
+			var touchpadElement = page.querySelector(".app-4way-touchpad"),
+				ontouch = function (ev) {
+					/*
+					 In this place developer should implement own touch event handler
+					 */
+					// lock the section change event listener
+					ev.stopPropagation();
+					// lock the default web engine behaviour eg. scrolling
+					ev.preventDefault();
+				};
+
+			tau.event.on(touchpadElement, ["touchstart", "touchmove", "touchend"], ontouch);
+		};
+
+	page.addEventListener("pagebeforeshow", onpagebeforeshow);
+})();
+


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1495
[Problem] when it scroll up/down or left/right, the screen is moving.
[Solution]
 - developer has to make own touch event handler for touchpad area

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>