### PR TITLE
Fix the "Uncaught TypeError" on UIComponent

### DIFF
--- a/src/js/profile/wearable/widget/wearable/ArcListview.js
+++ b/src/js/profile/wearable/widget/wearable/ArcListview.js
@@ -722,6 +722,10 @@
 					carouselItemUpperSeparatorElement,
 					top;
 
+				if (carousel.items.length === 0) {
+					return;
+				}
+
 				if (self.options.focusedTitle) {
 					self._updateFocusedTitle();
 				}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1500
[Problem] Cannot read property 'carouselElement' of undefined
[Solution] Update only when the number of carousel items is valid

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>