### PR TITLE
build: fix for npm build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "script-loader": "^0.7.2",
     "shelljs": "latest",
     "style-loader": "^0.23.1",
-    "svg-sprite": "^1.5.0",
+    "svg-sprite": "1.3.7",
     "underscore": "1.6.0",
     "webpack": "^4.29.6",
     "xml2js": "~0.4.4"

--- a/tools/grunt/tasks/svg-sprites.js
+++ b/tools/grunt/tasks/svg-sprites.js
@@ -26,8 +26,6 @@ module.exports = function (grunt) {
 		});
 
 		function convert(srcDir, destDir, fileMask) {
-			grunt.log.writeln("convert: " + srcDir);
-
 			return new Promise(function (resolve) {
 				var spriter; // instance of spriter
 
@@ -77,7 +75,6 @@ module.exports = function (grunt) {
 					spriter = new SVGSpriter(config);
 
 					Promise.all(queue).then(function (data) {
-						//console.log("all files read", data);
 						data.forEach(function (fileData) {
 							spriter.add(path.resolve(fileData.file), fileData.file, fileData.data);
 						});


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1504
[Problem] "svg-sprites:mobile" (svg-sprites) grun task fails
[Solution]
 - The svg-sprites module cause build issue because
 sub module css-tree has been updated and require ES6 Spread syntax

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>