### PR TITLE
AppBar: change widget selector to fix conflict with card header

### DIFF
--- a/src/js/core/widget/core/Appbar.js
+++ b/src/js/core/widget/core/Appbar.js
@@ -125,7 +125,7 @@
 			Appbar.prototype = prototype;
 			Appbar.defaults = defaults;
 			Appbar.classes = classes;
-			Appbar.selector = ".ui-appbar,.ui-header,header,[data-role='header']";
+			Appbar.selector = ".ui-appbar,.ui-page > .ui-header,.ui-page > header,[data-role='header']";
 
 			prototype._init = function (element) {
 				var self = this;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1499
[Problem] Card: conflict of Card header and Page appbar
[Solution]
 - sector detailing for appbar solves the problem

[Screenshot]
![obraz](https://user-images.githubusercontent.com/29534410/100732282-cf591980-33cc-11eb-8edd-73ac04fc8137.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>