### PR TITLE
Page: fix in appbar collapsing handler

### DIFF
--- a/src/js/core/widget/core/Page.js
+++ b/src/js/core/widget/core/Page.js
@@ -1004,7 +1004,9 @@
 						var scroller = self.getScroller(),
 							scrollview = ns.engine.getBinding(scroller);
 
-						scrollview.enableScrolling();
+						if (scrollview) {
+							scrollview.enableScrolling();
+						}
 					}, false);
 
 					header.addEventListener("appbarexpanded", function () {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1527
[Problem] Page: not existent scrollview instance in handler
 for appbar collapsing
[Solution]
 - added condition for checking scrollview existing

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>