### PR TITLE
NumberPicker: fix for option `data-drag-target`

### DIFF
--- a/src/js/core/widget/core/Spin.js
+++ b/src/js/core/widget/core/Spin.js
@@ -452,7 +452,7 @@
 			self.length = options.max - options.min + options.step;
 			self._count = self._valueToCount(options.value);
 
-			self.dragTarget = (options.dragTarget === "document") ? document : self.element;
+			self.dragTarget = (options.dragTarget === "self") ? self.element : document;
 
 			self._refresh();
 		};

--- a/src/js/profile/wearable/widget/wearable/NumberPicker.js
+++ b/src/js/profile/wearable/widget/wearable/NumberPicker.js
@@ -109,7 +109,8 @@
 					max: 12,
 					step: 1,
 					disabled: false,
-					accelerated: 0
+					accelerated: 0,
+					dragTarget: "self"
 				};
 
 				// other widgets instances using by number picker
@@ -244,7 +245,8 @@
 						rollHeight: "custom",
 						itemHeight: 38,
 						duration: 300,
-						value: element.value
+						value: element.value,
+						dragTarget: self.options.dragTarget
 					});
 				}
 			};

--- a/tests/manualTest/numeberPicker/number-0-2-drag-target-document.html
+++ b/tests/manualTest/numeberPicker/number-0-2-drag-target-document.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport" />
+	<title>
+		Wearable UI
+	</title>
+	<link href="../../../dist/wearable/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../../dist/wearable/theme/default/tau.circle.css" rel="stylesheet" />
+    <script src="../../../dist/wearable/js/tau.js">
+	</script>
+</head>
+
+<body>
+	<div class="ui-page" data-enable-page-scroll="false">
+		<div class="ui-content">
+			<label>
+				unit
+				<input max="2" min="0" step="1" type="number" value="0" id="number-picker" data-drag-target="document"/>
+			</label>
+		</div>
+    </div>
+    <script>
+        document.addEventListener("pagebeforeshow", function () {
+            widget = tau.widget.NumberPicker(document.getElementById("number-picker"));
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1530
[Problem] NumberPicker: option `data-drag-target` not supported
[Solution]
 - fix for providing `data-drag-target` option to Spin widget

[ManualTest]
 tests/manualTest/numeberPicker/number-0-2-drag-target-document.html

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>