### PR TITLE
NumberPicker: destroy Spin widget on NumberPicker destroying

### DIFF
--- a/src/js/profile/wearable/widget/wearable/NumberPicker.js
+++ b/src/js/profile/wearable/widget/wearable/NumberPicker.js
@@ -473,6 +473,7 @@
 				self._unbindEvents();
 
 				// destroy widgets
+				self._spin.destroy();
 				self._circleIndicator.destroy();
 
 				// remove classes


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1532
[Problem] Spin widget has to be destroy on NumberPicker destroying
[Solution]
 - NumberPicker destroy method has been modified

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>