### PR TITLE
Card: Disable word wrap in subheader

### DIFF
--- a/src/css/profile/mobile/common/card.less
+++ b/src/css/profile/mobile/common/card.less
@@ -20,6 +20,7 @@
 		.ui-content-subheader {
 			display: flex;
 			align-items: center;
+			white-space: nowrap;
 
 			&::after {
 				content: "";


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1562
[Problem] Text in card header is wrapped
[Solution]
 - text wrap has been disabled

[Screenshot]
![obraz](https://user-images.githubusercontent.com/29534410/103543623-24da8780-4e9f-11eb-983a-d34a0511fbae.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>