### PR TITLE
MainTab: fix for style of active item underline

### DIFF
--- a/src/css/profile/mobile/common/maintab.less
+++ b/src/css/profile/mobile/common/maintab.less
@@ -46,7 +46,8 @@
 				position: absolute;
 				width: 100%;
 				height: 4 * @px_base;
-				border-bottom: 2.5 * @px_base dotted var(--primary-dark-color);
+				border-bottom: 2.5 * @px_base solid var(--primary-dark-color);
+				border-radius: 1.25 * @px_base;
 				bottom: 0.75 * @px_base;
 				box-sizing: border-box;
 				opacity: 0;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1557
[Problem] MainTab: underline for active tab needs update
[Solution]
 - Style of actvie tab has been updated according to guideline

[Screenshot]
![obraz](https://user-images.githubusercontent.com/29534410/103651556-17d29c80-4f62-11eb-9ddd-07bf3cc2172f.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>