### PR TITLE
DropDownMenu: update widget style according to guideline

### DIFF
--- a/src/css/profile/mobile/base.less
+++ b/src/css/profile/mobile/base.less
@@ -88,7 +88,6 @@
 @toast-text-color: @_white;
 
 @content-area-line-color: #d6d6d6;
-@dropdown-list-box-shadow-color: fade(@_black, 35%);
 @calendar-weekend-day-color: #c95151;
 @progress-circle-second-color: #06b485;
 

--- a/src/css/profile/mobile/common/dropdownmenu.less
+++ b/src/css/profile/mobile/common/dropdownmenu.less
@@ -1,5 +1,3 @@
-@dropdown-options-margin: 3 * @px_base;
-
 .ui-dropdownmenu-overlay {
 	opacity: 0;
 	position: absolute;
@@ -55,7 +53,7 @@
 		vertical-align: middle;
 		position: relative;
 		height: 100%;
-		line-height: 120 * @unit_base;
+		line-height: 60 * @px_base;
 		white-space: nowrap;
 		padding: 0 26 * @px_base 0 16 * @px_base;
 		overflow: hidden;
@@ -66,7 +64,7 @@
 		&::after {
 			content: "";
 			position: absolute;
-			.calc-width(~"100% - " (64 * @unit_base));
+			.calc-width(~"100% - " (32 * @px_base));
 			height: 1 * @px_base;
 			bottom: 9 * @px_base;
 			right: 16 * @px_base;
@@ -161,19 +159,19 @@
 	}
 }
 
-@-webkit-keyframes open-to-bottom {
+@keyframes open-to-bottom {
 	.open-to-bottom();
 }
 
-@-webkit-keyframes open-to-top {
+@keyframes open-to-top {
 	.open-to-top();
 }
 
-@-webkit-keyframes close-to-bottom {
+@keyframes close-to-bottom {
 	.close-to-bottom();
 }
 
-@-webkit-keyframes close-to-top {
+@keyframes close-to-top {
 	.close-to-top();
 }
 
@@ -186,11 +184,12 @@
 	z-index: 1201;
 	min-width: 168px;
 	max-width: 100vw;
-	padding: 3 * @px_base;
+	padding: 5 * @px_base;
+	margin-top: -5.5 * @px_base;
 
 	&.ui-dropdownmenu-options-vertical-margins {
-		margin-top: @dropdown-options-margin;
-		margin-bottom: @dropdown-options-margin;
+		margin-top: 0.5 * @px_base;
+		margin-bottom: 4.5 * @px_base;
 	}
 	&.ui-dropdownmenu-active {
 		visibility: visible;
@@ -214,11 +213,11 @@
 		list-style: none;
 		padding: 0;
 		margin: 0;
-		max-height: calc(~"100vh - "2 * @dropdown-options-margin);
+		max-height: calc(~"100vh - "2 * 5 * @px_base);
 		overflow-y: auto;
 		background-color: var(--dropdown-menu-options-background);
 		border-radius: 26 * @px_base;
-		box-shadow: 0 0 3 * @px_base 0 @dropdown-list-box-shadow-color;
+		box-shadow: 0 2.5 * @px_base 8 * @px_base 0 var(--dropdown-shadow-color-1), 0 0 2.5 * @px_base 0 var(--dropdown-shadow-color-2);
 		border: var(--dropdown-menu-options-border);
 		&:focus {
 			outline: none;
@@ -238,7 +237,7 @@
 				margin-right: 24 * @px_base;
 				content: '';
 				position: absolute;
-				mask-image: url('images/1_App_bar/tw_ic_ab_back_mtrl.svg');
+				mask-image: url('images/13_View_controls/tw_dropdown_ic_check.svg');
 				mask-size: 100%, 0;
 				mask-position: center;
 				mask-repeat: no-repeat;

--- a/src/css/profile/mobile/common/oneui-common.less
+++ b/src/css/profile/mobile/common/oneui-common.less
@@ -26,6 +26,9 @@
     --popup-scroll-divider-color: @popup-scroll-divider-color;
     --icon-color: @icon-color; // dropdown menu
 
+    --dropdown-shadow-color-1: @dropdown-list-box-shadow-color-1;
+    --dropdown-shadow-color-2: @dropdown-list-box-shadow-color-2;
+
     --appbar-main-text-color: @appbar-main-text-color;
     --appbar-subtitle-color: @appbar-sub-title-color;
     --appbar-miltiline-title-color: @appbar-multiline-title-color;

--- a/src/css/profile/mobile/theme-changeable/images/13_View_controls/tw_dropdown_ic_check.svg
+++ b/src/css/profile/mobile/theme-changeable/images/13_View_controls/tw_dropdown_ic_check.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="60px" height="60px" viewBox="0 0 60 60" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>PNG/Light/Winset/List/tw_dropdown_ic_check</title>
+    <defs>
+        <path d="M57.839625,13.282876 C56.960625,12.403876 55.532625,12.406876 54.656625,13.285876 L25.379625,42.655876 C25.184625,42.844876 24.962625,42.874876 24.845625,42.874876 C24.731625,42.874876 24.506625,42.844876 24.314625,42.655876 L5.34562499,23.626876 C4.46662499,22.744876 3.04162499,22.744876 2.16262499,23.620876 C1.28062499,24.499876 1.27762499,25.924876 2.15662499,26.803876 L21.128625,45.832876 C22.121625,46.828876 23.441625,47.374876 24.845625,47.374876 C26.252625,47.374876 27.572625,46.828876 28.562625,45.832876 L57.845625,16.465876 C58.721625,15.583876 58.718625,14.158876 57.839625,13.282876" id="path-1"></path>
+    </defs>
+    <g id="PNG/Light/Winset/List/tw_dropdown_ic_check" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <mask id="mask-2" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+        <use id="Done-/-Selected" fill="#000000" fill-rule="nonzero" xlink:href="#path-1"></use>
+    </g>
+</svg>

--- a/src/css/profile/mobile/themes/dark.variables.less
+++ b/src/css/profile/mobile/themes/dark.variables.less
@@ -23,6 +23,9 @@
     @more-options-pressed-color: @_white;
     @more-options-pressed-opacity: 20%;
 
+    @dropdown-list-box-shadow-color-1: fade(@_black, 35%);
+    @dropdown-list-box-shadow-color-2: fade(@_black, 10%);
+
     @appbar-main-text-color: @color-white;
     @appbar-sub-title-color: #9c9c9c;
     @appbar-multiline-title-color: #e5e5e5;

--- a/src/css/profile/mobile/themes/light.variables.less
+++ b/src/css/profile/mobile/themes/light.variables.less
@@ -23,6 +23,9 @@
     @more-options-pressed-color: @_black;
     @more-options-pressed-opacity: 10%;
 
+    @dropdown-list-box-shadow-color-1: fade(@_black, 15%);
+    @dropdown-list-box-shadow-color-2: fade(@_black, 4%);
+
     @appbar-main-text-color: @text-color;
     @appbar-sub-title-color: #636363;
     @appbar-multiline-title-color: @text-color;

--- a/src/js/profile/mobile/widget/DropdownMenu.js
+++ b/src/js/profile/mobile/widget/DropdownMenu.js
@@ -1026,10 +1026,13 @@
 					optionHeight = ui.elOptionContainer.offsetHeight,
 					listItemWidthOffsets = [].slice.call(ui.elOptionContainer.children).map(mapItemWidth),
 					optionContainerStyle = window.getComputedStyle(ui.elOptionContainer),
+					wrapperStyle = window.getComputedStyle(ui.elOptionWrapper),
 					biggestListItemWidth = Math.max.apply(Math, listItemWidthOffsets) +
 						parseInt(optionContainerStyle.borderLeftWidth, 10) +
 						parseInt(optionContainerStyle.borderRightWidth, 10),
-					wrapperMinWidth = parseInt(window.getComputedStyle(ui.elOptionWrapper).minWidth, 10),
+					wrapperPaddingLeftRight = parseInt(wrapperStyle.paddingLeft, 10) +
+						parseInt(wrapperStyle.paddingRight, 10),
+					wrapperMinWidth = parseInt(wrapperStyle.minWidth, 10),
 					options = self.options,
 					scrollTop = ui.elOptionWrapper.parentNode.querySelector(".ui-scrollview-clip").scrollTop,
 					height,
@@ -1048,13 +1051,20 @@
 				width = Math.max(biggestListItemWidth, wrapperMinWidth);
 				height = optionHeight;
 
+				if (width + wrapperPaddingLeftRight > window.screen.width) {
+					width = window.screen.width - wrapperPaddingLeftRight;
+				}
+
 				// This part decides the location and direction of option list.
-				offsetLeft = self._horizontalPosition === "right" ? widgetParentRect.right - width : widgetParentRect.left;
+				offsetLeft = self._horizontalPosition === "right" ? widgetParentRect.right - width - wrapperPaddingLeftRight :
+					widgetParentRect.left;
 				// if drop down menu goes out screen eg. more menu
 				// left position has to be corrected
-				if (offsetLeft + width > window.screen.width) {
-					offsetLeft -= offsetLeft + width - window.screen.width;
+
+				if (offsetLeft + width + wrapperPaddingLeftRight > window.screen.width) {
+					offsetLeft -= offsetLeft + width + wrapperPaddingLeftRight - window.screen.width;
 				}
+
 				optionStyle = "left: " + offsetLeft + "px; ";
 
 				if (options.inline === true) {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1556
[Problem] Dropdown list looks different then in guideline
[Solution]
 - css styles have been updated

[Scrennshot]

![obraz](https://user-images.githubusercontent.com/29534410/104024815-fd97f900-51c3-11eb-9681-c538618177f8.png)
![obraz](https://user-images.githubusercontent.com/29534410/104024732-db9e7680-51c3-11eb-805d-bb7d12f5dda0.png)
![obraz](https://user-images.githubusercontent.com/29534410/104024761-eb1dbf80-51c3-11eb-9cd6-7c2caf6e512c.png)
![obraz](https://user-images.githubusercontent.com/29534410/104024865-0e486f00-51c4-11eb-959d-32277530c49b.png)





Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>