### PR TITLE
Master On-Off Switch: update widget colors

### DIFF
--- a/src/css/profile/mobile/common/masteronoffswitch.less
+++ b/src/css/profile/mobile/common/masteronoffswitch.less
@@ -44,7 +44,7 @@
         }
 
         &-on {
-            color: var(--color-white);
+            color: var(--primary-dark-color);
             background-color: var(--master-on-off-on-color);
         }
     }

--- a/src/css/profile/mobile/themes/dark.variables.less
+++ b/src/css/profile/mobile/themes/dark.variables.less
@@ -47,7 +47,7 @@
     @on-off-switch-divider-opacity: 15%;
 
     @master-on-off-off-color: fade(@color-white, 17%);
-    @master-on-off-on-color: fade(@control-active-color, 40%);
+    @master-on-off-on-color: fade(@control-active-color, 32%);
 
     @chip-background-color: @background-area-color;
     @chip-border-color: #fafafa;

--- a/src/css/profile/mobile/themes/light.variables.less
+++ b/src/css/profile/mobile/themes/light.variables.less
@@ -52,7 +52,7 @@
     @on-off-switch-divider-color: #c4c4c4;
     @on-off-switch-divider-opacity: 100%;
     @master-on-off-off-color: @color-white;
-    @master-on-off-on-color: fade(@control-active-color, 80%);
+    @master-on-off-on-color: #aad2fa;
 
     @chip-background-color: #e5e5e5;
     @chip-border-color: #252525;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1573
[Problem] Widget colors are outdated
[Solution]
 - Colors have been updated

[Screenshot]
![image](https://user-images.githubusercontent.com/29534410/106297718-4d159600-6253-11eb-995a-41793ee4ad7f.png)

![image](https://user-images.githubusercontent.com/29534410/106297765-5bfc4880-6253-11eb-95c5-612005c76f05.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>