### PR TITLE
Spinner: add new DropDownMenu style

### DIFF
--- a/examples/mobile/UIComponents/components/view-controls/index.html
+++ b/examples/mobile/UIComponents/components/view-controls/index.html
@@ -38,6 +38,11 @@
 					</a>
 				</li>
 				<li class="ui-li-anchor">
+					<a href="spinner/spinner.html">
+						Spinner
+					</a>
+				</li>
+				<li class="ui-li-anchor">
 					<a href="main-tab/index.html">
 						Main Tab
 					</a>

--- a/examples/mobile/UIComponents/components/view-controls/spinner/spinner.html
+++ b/examples/mobile/UIComponents/components/view-controls/spinner/spinner.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta content="width=device-width, user-scalable=no" name="viewport" />
+	<link href="../../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../../css/style.css" rel="stylesheet" />
+	<script data-build-remove="false" src="../../../lib/tau/mobile/js/tau.js">
+	</script>
+</head>
+
+<body>
+	<div class="ui-page" id="spinner-page">
+		<header>
+			<div class="ui-appbar-left-icons-container">
+				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
+			</div>
+			<div class="ui-appbar-title-container">
+				<span class="ui-appbar-title">Spinner</span>
+			</div>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+				<select class="theme-changer" data-native-menu="false" style="display: none">
+					<option value="light">
+						Light Theme
+					</option>
+					<option value="dark" class="ui-dropdown-two-lines">
+						Dark Theme
+					</option>
+				</select>
+			</div>
+		</header>
+		<div class="ui-content">
+			<ul class="ui-listview ui-content-area">
+				<li class="ui-li-static ui-li-has-dropdownmenu">
+					<select data-native-menu="false" name="select-custom-1" data-style="spinner">
+						<option data-placeholder="true" value="first-line" data-hide-placeholder-menu-items="false">
+							Sub app bar
+						</option>
+						<option value="1">
+								Option 1
+						</option>
+						<option value="2">
+								Option 2
+						</option>
+						<option value="3">
+								Option 3
+						</option>
+						<option value="4">
+								Option 4
+						</option>
+					</select>
+				</li>
+			</ul>
+			<ul class="ui-listview">
+				<li class="ui-li-static ui-li-has-dropdownmenu">
+					<select data-native-menu="false" name="select-custom-1" data-style="spinner">
+						<option data-placeholder="true" value="first-line" data-hide-placeholder-menu-items="false">
+							ID
+						</option>
+						<option value="1">
+								Option 1
+						</option>
+						<option value="2">
+								Option 2
+						</option>
+						<option value="3">
+								Option 3
+						</option>
+						<option value="4">
+								Option 4
+						</option>
+					</select>
+				</li>
+				<li class="ui-li-static ui-li-has-dropdownmenu">
+					<select data-native-menu="false" name="select-custom-2" data-style="spinner">
+						<option data-placeholder="true" value="second-line">
+							Password
+						</option>
+						<option value="1">
+							Option 1
+						</option>
+						<option value="2">
+							Option 2
+						</option>
+						<option value="3">
+							Option 3
+						</option>
+						<option value="4">
+							Option 4
+						</option>
+					</select>
+				</li>
+			</ul>
+		</div>
+	</div>
+	<!-- /page -->
+</body>
+
+</html>

--- a/src/css/profile/mobile/common/dropdownmenu.less
+++ b/src/css/profile/mobile/common/dropdownmenu.less
@@ -308,3 +308,19 @@
 .ui-appbar-expanded .ui-dropdownmenu-placeholder {
 	line-height: (56 + 3) * @px_base; // compensate top margin
 }
+
+.ui-spinner {
+	.ui-dropdownmenu-placeholder::after {
+		content: "";
+		width: 20 * @px_base;
+		height: 20 * @px_base;
+		position: absolute;
+		right: 0;
+		background-color:black;
+		top: 35%;
+		mask-image: url(images/13_View_controls/tw_spinner_mtrl.svg);
+	}
+	.ui-dropdownmenu-active .ui-dropdownmenu-placeholder::after {
+		display: none;
+	}
+}

--- a/src/js/profile/mobile/widget/DropdownMenu.js
+++ b/src/js/profile/mobile/widget/DropdownMenu.js
@@ -188,13 +188,15 @@
 					 * @property {boolean} [options.inline=false] Sets the DropdownMenu widget as inline/normal type.
 					 * @property {boolean} [options.hidePlaceholderMenuItems=true] Hide/Reveal the placeholder option in dropdown list of the DropdownMenu.
 					 * @property {string}  [options.items=''] List of <option>: 'key1:value1, key2:value2, key3:value3 .....'
+					 * @property {string}  [options.style='dropdown'] style of dropdown widget: 'dropdown', 'spinner'
 					 * @member ns.widget.mobile.DropdownMenu
 					 */
 					self.options = {
 						nativeMenu: true,
 						inline: false,
 						hidePlaceholderMenuItems: true,
-						items: ""
+						items: "",
+						style: "dropdown"
 					};
 					/**
 					 * @property {Function|null} _toggleMenuBound callback for select action
@@ -370,7 +372,13 @@
 					 * @style "ui-dropdownmenu-options-vertical-margins"
 					 * @member ns.widget.mobile.DropdownMenu
 					 */
-					verticalMargins: "ui-dropdownmenu-options-vertical-margins"
+					verticalMargins: "ui-dropdownmenu-options-vertical-margins",
+					/**
+					 * Set top and bottom margins for dropdownmenu
+					 * @style "ui-dropdownmenu-options-vertical-margins"
+					 * @member ns.widget.mobile.DropdownMenu
+					 */
+					spinner: "ui-spinner"
 				},
 				prototype = new BaseWidget();
 
@@ -522,6 +530,7 @@
 					classList.remove(BaseWidget.classes.disable);
 				}
 			}
+
 			/**
 			 * Return data array used to fill select tag options elements
 			 * @method dataItemsToArray
@@ -887,6 +896,29 @@
 			};
 
 			/**
+			 * Set widget style
+			 * @method setStyle
+			 * @protected
+			 * @static
+			 * @param {HTMLElement} element
+			 * @param {string} style
+			 * @member ns.widget.mobile.DropdownMenu
+			 */
+			prototype._setStyle = function (element, style) {
+				var self = this,
+					ui = self._ui;
+
+				if (style === "spinner") {
+					ui.elSelectWrapper.classList.add(classes.spinner);
+					self._setInline(element, true);
+				} else if (style === "dropdown") {
+					ui.elSelectWrapper.classList.remove(classes.spinner);
+				} else {
+					ns.warn("DropDownMenu: not supported style '" + style + "'");
+				}
+			};
+
+			/**
 			 * Init of DropdownMenu widget
 			 * @method _init
 			 * @param {HTMLElement} element
@@ -909,6 +941,8 @@
 						ui.elOptions = ui.elOptionContainer.querySelectorAll("li[data-value]");
 					}
 				}
+				// set widget style: dropdown | spinner
+				self._setStyle(element, self.options.style);
 			};
 
 			/**


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/872
[Problem] View Controls -> Spinner -> missing spinner
[Solution]
 - The Spinner component has been implemented
   as style of DropDownMenu widget

[Screenshot]
![image](https://user-images.githubusercontent.com/29534410/106307986-5fe29780-6260-11eb-849d-c71f2344dd16.png)

![image](https://user-images.githubusercontent.com/29534410/106308034-6cff8680-6260-11eb-9ef0-c70f54ad2ab8.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>