### PR TITLE
KeyboardSupport: fix for focus change calculation

### DIFF
--- a/src/js/core/widget/BaseKeyboardSupport.js
+++ b/src/js/core/widget/BaseKeyboardSupport.js
@@ -547,14 +547,14 @@
 			function sortByDistance(a, b) {
 				return (a.distanceByDirection.distance === b.distanceByDirection.distance) ?
 					sortByDistanceByCenter(a, b) :
-						(a.distanceByDirection.distance < b.distanceByDirection.distance) ? -1 : 1;
+					(a.distanceByDirection.distance < b.distanceByDirection.distance) ? -1 : 1;
 			}
 
 			function sortByInSideDistanceLimit(a, b) {
 				// sort by inSideDistanceLimit
 				return (a.inSideDistanceLimit && b.inSideDistanceLimit) ? sortByDistance(a, b) :
-						(!a.inSideDistanceLimit && !b.inSideDistanceLimit) ? sortByDistanceByCenter(a, b) :
-							(a.inSideDistanceLimit && !b.inSideDistanceLimit) ? -1 : 1;
+					(!a.inSideDistanceLimit && !b.inSideDistanceLimit) ? sortByDistanceByCenter(a, b) :
+						(a.inSideDistanceLimit && !b.inSideDistanceLimit) ? -1 : 1;
 			}
 
 			/**
@@ -651,8 +651,7 @@
 							distanceByDirection: distanceByDirection,
 							distanceByCenter: getDistanceByCenter(focusableElementRect, elementRect),
 							inLine: isInLine(focusableElementRect, elementRect, direction),
-							inSideDistanceLimit: distanceByDirection.distance >= 0 &&
-								distanceByDirection.distance < SIDE_DISTANCE_LIMIT
+							inSideDistanceLimit: Math.abs(distanceByDirection.distance) < SIDE_DISTANCE_LIMIT
 						});
 					}
 


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1595
[Problem] The focus on the listview moves every 2 items
[Solution] Change of condition for filter of focusable elements
     which very near by selves.
    
Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>
