### PR TITLE
Button: fix for text align of button on anchor element

### DIFF
--- a/src/css/profile/mobile/common/button.less
+++ b/src/css/profile/mobile/common/button.less
@@ -490,8 +490,10 @@ a.ui-btn {
 		&:not(.ui-btn-inline) {
 			max-width: 75%;
 			width: 60%;
-			display: block;
+			display: flex;
 			margin: 0 auto;
+			justify-content: center;
+			align-items: center;
 		}
 		&.ui-state-disabled {
 			opacity: 0.4;


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1634
[Problem] Text should be in the middle of button
[Solution]
 - added new css styles for button

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>