### PR TITLE
Dividers: thumbnail list with text

### DIFF
--- a/examples/mobile/UIComponents/components/dividers/divider-thumbnail-text.html
+++ b/examples/mobile/UIComponents/components/dividers/divider-thumbnail-text.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta content="width=device-width, user-scalable=no" name="viewport" />
+	<link href="../../lib/tau/mobile/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../css/style.css" rel="stylesheet" />
+	<script data-build-remove="false" src="../../lib/tau/mobile/js/tau.js">
+	</script>
+</head>
+
+<body>
+	<div class="ui-page">
+		<header>
+			<div class="ui-appbar-left-icons-container">
+				<a href="#" class="ui-btn ui-btn-icon ui-btn-icon-back" data-style="flat" data-rel="back"></a>
+			</div>
+			<div class="ui-appbar-title-container">
+				<span class="ui-appbar-title">Sample title</span>
+			</div>
+			<div class="ui-appbar-action-buttons-container">
+				<button class="ui-btn ui-btn-icon ui-btn-icon-more" data-style="flat"></button>
+			</div>
+		</header>
+		<div class="ui-content">
+			<ul class="ui-listview ui-content-area ui-listview-thumb-circle">
+				<li class="ui-li-has-icon ui-li-divider">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_001.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							First line
+						</span>
+					</div>
+				</li>
+				<li class="ui-li-has-icon ui-li-divider">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_002.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							Second line
+						</span>
+					</div>
+				</li>
+				<li class="ui-li-has-icon ui-li-divider">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_003.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							Third line
+						</span>
+					</div>
+				</li>
+				<li class="ui-li-has-icon ui-li-divider">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_004.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							Fourth line
+						</span>
+					</div>
+				</li>
+				<li class="ui-li-has-icon">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_005.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							Fifth
+						</span>
+					</div>
+				</li>
+			</ul>
+
+			<div class="ui-content-subheader">Subheader</div>
+
+			<ul class="ui-listview ui-content-area ui-listview-thumb-rounded">
+				<li class="ui-li-has-icon ui-li-divider">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_006.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							Sixth line
+						</span>
+						<span class="ui-li-text-sub">
+							This screen is not settings app.
+						</span>
+					</div>
+				</li>
+				<li class="ui-li-has-icon ui-li-divider">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_007.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							Seventh line
+						</span>
+						<span class="ui-li-text-sub">
+							This screen is not settings app.
+						</span>
+					</div>
+				</li>
+				<li class="ui-li-has-icon ui-li-divider">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_008.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							Eighth line
+						</span>
+						<span class="ui-li-text-sub">
+							This screen is not settings app.
+						</span>
+					</div>
+				</li>
+				<li class="ui-li-has-icon ui-li-divider">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_009.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							Ninth line
+						</span>
+						<span class="ui-li-text-sub">
+							This screen is not settings app.
+						</span>
+					</div>
+				</li>
+				<li class="ui-li-has-icon">
+					<div class="ui-li-icon">
+						<img src="../../images/Thumbnail/thumbnail_010.jpg"/>
+					</div>
+					<div class="ui-li-text">
+						<span class="ui-li-text-title">
+							Tenth line
+						</span>
+						<span class="ui-li-text-sub">
+							This screen is not settings app.
+						</span>
+					</div>
+				</li>
+			</ul>
+
+		</div>
+	</div>
+</body>
+
+</html>

--- a/examples/mobile/UIComponents/components/dividers/index.html
+++ b/examples/mobile/UIComponents/components/dividers/index.html
@@ -43,6 +43,11 @@
 					</a>
 				</li>
 				<li class="ui-li-anchor">
+					<a href="divider-thumbnail-text.html">
+						Divider (Thumbnail + Text list)
+					</a>
+				</li>
+				<li class="ui-li-anchor">
 					<a href="divider-switch.html">
 						Divider (Switch)
 					</a>


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1621
[Problem] Template of dividers on thubnail list is not imeplemented
[Solution]
 - new template has been added

[Screenshot]
![obraz](https://user-images.githubusercontent.com/29534410/111429906-ead8fd80-86f9-11eb-9f9b-7e1ce591378d.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>