### PR TITLE
Button: set text in middle of contained button bassed on anchor

### DIFF
--- a/src/css/profile/mobile/common/button.less
+++ b/src/css/profile/mobile/common/button.less
@@ -563,6 +563,8 @@ a.ui-btn {
 			min-height: 36 * @px_base;
 			padding-top: 0;
 			padding-bottom: 0;
+			display: inline-flex;
+			align-items: center;
 		}
 	}
 	.ui-btn-flat, .ui-btn-contained {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1645
[Problem] Text on button is not verticaly centered
[Solution]
 - added new styles for contained button on listview

[Screenshot]
![obraz](https://user-images.githubusercontent.com/29534410/111640691-ba2dbc80-87fc-11eb-8e12-df18ea745799.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>