### PR TITLE
Progress: wrong margin for progress in button on listview

### DIFF
--- a/src/css/profile/mobile/common/progress.less
+++ b/src/css/profile/mobile/common/progress.less
@@ -398,7 +398,7 @@ tau-progress {
 	padding-left: 56 * @px_base;
 	padding-right: 56 * @px_base;
 }
-.ui-listview li > .ui-li-action .ui-progress.ui-indeterminate-circle {
+.ui-listview li > .ui-li-action > .ui-progress.ui-indeterminate-circle {
 	margin-right: 24 * @px_base;
 }
 .ui-listview li > .ui-progress.ui-indeterminate-circle {


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1650
[Problem] Progress has wrong margin
[Solution]
 - css selector for progress has been changed

[Screenshot]
![obraz](https://user-images.githubusercontent.com/29534410/111742639-cfe8c380-8888-11eb-8941-e9893759579c.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>