### PR TITLE
Dialog: changing focus on dialog show

### DIFF
--- a/src/js/core/widget/core/Popup.js
+++ b/src/js/core/widget/core/Popup.js
@@ -282,6 +282,8 @@
 					var self = this,
 						ui = {};
 
+					BaseKeyboardSupport.call(this);
+
 					self.selectors = selectors;
 					self.options = objectUtils.merge({}, Popup.defaults);
 					self.storedOptions = null;
@@ -851,7 +853,7 @@
 				var self = this;
 
 				self._setActive(true);
-				if (self.isKeyboardSupport) {
+				if (self.isKeyboardSupport && ns.getConfig("keyboardSupport")) {
 					self.disableFocusableElements(this._ui.page);
 					self.enableDisabledFocusableElements(this.element);
 					BaseKeyboardSupport.focusElement(this.element);


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1640
[Problem] Remote control doesn't work on Dialog window
[Solution]
 - base keyboard support has been enabled for dialog

[Screenshot]
![image](https://user-images.githubusercontent.com/29534410/112288008-37d64a00-8c8d-11eb-9149-e7a1108de143.png)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>