### PR TITLE
Slider: fix for keyboard support - remote control

### DIFF
--- a/src/css/profile/mobile/base.less
+++ b/src/css/profile/mobile/base.less
@@ -133,5 +133,7 @@
     --on-off-switch-off-disabled-track-border: @on-off-switch-off-disabled-track-border;
 
     --focus-outline-color: rgb(69, 143, 255);
+    --focus-bg-color: fade(rgb(69, 143, 255), 10%);
+
     --text-field-icon-color: @text-field-icon-color;
 }

--- a/src/css/profile/mobile/common/slider.less
+++ b/src/css/profile/mobile/common/slider.less
@@ -21,6 +21,9 @@
 	&:focus {
 		outline: none;
 	}
+	&.ui-focus {
+		background-color: var(--focus-bg-color);
+	}
 
 	.ui-slider-handler-track {
 		position: absolute;
@@ -57,6 +60,13 @@
 			border-radius: 100%;
 			background-color: var(--ripple-color);
 		}
+		&.ui-focus {
+			&::before {
+				opacity: 1;
+				left: -7 * @px_base;
+				top: -7 * @px_base;
+			}
+		}
 	}
 
 	&.ui-slider-active {
@@ -65,6 +75,8 @@
 			min-height: 22 * @px_base;
 			&::before {
 				opacity: 1;
+				left: -5 * @px_base;
+				top: -5 * @px_base;
 			}
 		}
 	}

--- a/src/js/core/widget/BaseKeyboardSupport.js
+++ b/src/js/core/widget/BaseKeyboardSupport.js
@@ -1153,6 +1153,14 @@
 				return false;
 			};
 
+			prototype._unlockFocusSelf = function () {
+				var current = activeElement || getFocusedLink();
+
+				if (current) {
+					unlockFocus(this, current);
+				}
+			};
+
 			/**
 			 * Supports keyboard long press event.
 			 * It is called on keydown event, when the long press was not detected.


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1654
[Problem] Slider doesn't support remote control
[Solution]
 - add keyboard support for slider and fixes

[Screenshot]
![slider-1](https://user-images.githubusercontent.com/29534410/112459166-d631e080-8d5d-11eb-9695-4e043c9bc746.gif)
![slider-2](https://user-images.githubusercontent.com/29534410/112459178-d92cd100-8d5d-11eb-8a09-a444d3517d4e.gif)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>