### PR TITLE
TextField: add focus style

### DIFF
--- a/examples/tv/UIComponents/components/textfields/textfields-with-label.html
+++ b/examples/tv/UIComponents/components/textfields/textfields-with-label.html
@@ -3,7 +3,7 @@
 
 <head>
 	<meta content="width=device-width, user-scalable=no" name="viewport" />
-	<link href="../../lib/tau/tv/theme/default/tau.css" rel="stylesheet" />
+	<link href="../../lib/tau/tv/theme/changeable/tau.css" rel="stylesheet" />
 	<link href="../../css/style.css" rel="stylesheet" />
 	<script data-build-remove="false" src="../../lib/tau/tv/js/tau.js">
 	</script>
@@ -37,6 +37,10 @@
 				<li class="ui-li-has-text-input">
 					<label for="text-label-4">Label</label>
 					<input type="text" value="Input text" id="text-label-4"/>
+				</li>
+				<li class="ui-li-has-text-input">
+					<label for="text-label-2">Press enter to edit</label>
+					<input class="input-hint" data-edit-on-focus="false" placeholder="Edit text" type="text"/>
 				</li>
 				<li class="ui-li-has-text-input">
 					<label for="text-label-5">Label</label>

--- a/src/css/profile/mobile/common/textinput.less
+++ b/src/css/profile/mobile/common/textinput.less
@@ -199,10 +199,6 @@ textarea.ui-text-input {
 	& ~ .ui-text-input-clear-hidden {
 		visibility: hidden;
 	}
-
-	&.ui-text-input-widget-focused {
-		background-color: var(--textual-background);
-	}
 }
 
 /*special case of buttons and text-inputs:

--- a/src/js/profile/mobile/widget/TextInput.js
+++ b/src/js/profile/mobile/widget/TextInput.js
@@ -1126,27 +1126,33 @@
 				var classList = element.classList;
 
 				classList.add(classes.WIDGET_FOCUSED);
+				if (element.getAttribute("data-edit-on-focus") !== "false") {
+					element.focus();
+					ns.event.trigger(element, "focus");
+				} else {
+					this._ui.label.classList.add(classes.ACTIVATED);
+				}
 			}
 
 			prototype._blur = function (element) {
 				var classList = element.classList;
 
 				classList.remove(classes.WIDGET_FOCUSED);
+				ns.event.trigger(element, "blur");
 				element.blur();
 			}
 
 			prototype._actionEnter = function (element) {
-				var self = this;
-
-				self._blur(element);
-				element.focus();
+				if (element.getAttribute("data-edit-on-focus") === "false") {
+					element.focus();
+					ns.event.trigger(element, "focus");
+				}
 			}
 
 			prototype._actionEscape = function (element) {
-				var self = this;
-
-				element.blur();
-				self.focus();
+				if (element.getAttribute("data-edit-on-focus") === "false") {
+					ns.event.trigger(element, "blur");
+				}
 			}
 
 			BaseKeyboardSupport.registerActiveSelector("input[type='text']:not([data-role])" +


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1660
[Problem] TextField selected by remote control is not visual focused
[Solution]
  - added new css style
  - added new option for TextField: data-edit-on-focus="false" (default: true)
        This option require enter press for edit text field - usefully for TV

[Screenshot]
![text-field-1](https://user-images.githubusercontent.com/29534410/112674264-fc42a800-8e65-11eb-9d6d-cc26593464e3.gif)
    

 Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>