### PR TITLE
Calendar: add support for remote control

### DIFF
--- a/examples/mobile/UIComponents/components/dialogs/pickers/calendar.html
+++ b/examples/mobile/UIComponents/components/dialogs/pickers/calendar.html
@@ -20,9 +20,7 @@
 			</h1>
 		</div>
 		<div class="ui-content">
-			<ul class="ui-listview ui-content-area">
-				<div class="ui-calendar" data-past-selection="true"></div>
-			</ul>
+			<div class="ui-calendar ui-content-area" data-past-selection="true"></div>
 		</div>
 	</div>
 </body>

--- a/examples/tv/UIComponents/components/dialogs/pickers/calendar.html
+++ b/examples/tv/UIComponents/components/dialogs/pickers/calendar.html
@@ -20,9 +20,7 @@
 			</h1>
 		</div>
 		<div class="ui-content">
-			<ul class="ui-listview ui-content-area">
-				<div class="ui-calendar" data-past-selection="true"></div>
-			</ul>
+			<div class="ui-calendar ui-content-area" data-past-selection="true"></div>
 		</div>
 	</div>
 </body>

--- a/src/css/profile/mobile/common/calendar.less
+++ b/src/css/profile/mobile/common/calendar.less
@@ -8,7 +8,7 @@
 				text-align: center;
 				vertical-align: middle;
 				font-size: 15 * @sp_base;
-				.font(regular); 
+				.font(regular);
 				color: var(--calendar-text-color);
 				padding: 0;
 				div {
@@ -82,7 +82,7 @@
 	&-top-space {
 		height: 10 * @px_base;
 	}
-	
+
 	&-prev-month-day {
 		opacity: 0.1;
 	}
@@ -109,18 +109,35 @@
 	&-arrow {
 		width: 36 * @px_base;
 		height: 36 * @px_base;
-		mask-repeat: no-repeat;
-		mask-position: center;
-		mask-size: 100%;
-		background-color: var(--calendar-arrow-color);
+		position: relative;
+
+		&::after {
+			content: "";
+			position: absolute;
+			background-color: var(--calendar-arrow-color);
+			width: 100%;
+			height: 100%;
+			left: 0;
+			top: 0;
+			mask-repeat: no-repeat;
+			mask-position: center;
+			mask-size: 100%;
+		}
 	}
 	&-left-arrow {
 		float: left;
-		mask-image: url("images/4_Dialogs/tw_numberpicker_prev_mtrl.svg");
+
+		&::after {
+			mask-image: url("images/4_Dialogs/tw_numberpicker_prev_mtrl.svg");
+		}
+
 	}
 	&-right-arrow {
 		float: right;
-		mask-image: url("images/4_Dialogs/tw_numberpicker_next_mtrl.svg");
+
+		&::after {
+			mask-image: url("images/4_Dialogs/tw_numberpicker_next_mtrl.svg");
+		}
 	}
 
 	&-disabled {
@@ -136,7 +153,9 @@
 			margin: 0 auto;
 		}
 	}
-	
+	&.ui-focus, .ui-focus {
+		outline: 2 * @px_base solid var(--focus-outline-color);
+	}
 }
 
 .ui-content-area, .ui-popup-content {

--- a/src/js/core/widget/BaseKeyboardSupport.js
+++ b/src/js/core/widget/BaseKeyboardSupport.js
@@ -1,4 +1,4 @@
-/*global window, define, ns, HTMLElement, Node */
+/*global define, ns */
 /*
  * Copyright (c) 2010 - 2014 Samsung Electronics Co., Ltd.
  * License : MIT License V2
@@ -885,14 +885,15 @@
 			 */
 			function unlockFocus(self, element) {
 				var widget;
-				// enable escape from children (usability)
 
+				// enable escape from children (usability)
 				if (DOM.getNSData(element, "focus-lock") !== true) {
 					element = selectorUtils.getClosestBySelectorNS(element.parentNode, "focus-lock=true");
 					if (!element) {
 						return false;
 					}
 				}
+
 				widget = engine.getBinding(element);
 				if (widget && widget === currentKeyboardWidget) {
 					widget.disableKeyboardSupport();
@@ -1020,10 +1021,11 @@
 			 * @member ns.widget.tv.BaseKeyboardSupport
 			 */
 			prototype._onKeyup = function (event) {
-				var self = this,
+				var self = currentKeyboardWidget || this,
 					keyboardSupportState = ns.getConfig("keyboardSupport", false);
 
 				if (keyboardSupportState && self._supportKeyboard) {
+
 					if (!self.keydownEventRepeated) {
 						// short press was detected
 						self._onShortPress(event);

--- a/src/js/profile/mobile/widget/Calendar.js
+++ b/src/js/profile/mobile/widget/Calendar.js
@@ -35,11 +35,13 @@
 			"../../../core/engine",
 			"../../../core/util/DOM/attributes",
 			"../../../core/event",
+			"../../../core/widget/BaseKeyboardSupport",
 			"../widget"
 		],
 		function () {
 			//>>excludeEnd("tauBuildExclude");
 			var utilsObject = ns.util.object,
+				BaseKeyboardSupport = ns.widget.core.BaseKeyboardSupport,
 				engine = ns.engine,
 				events = ns.event,
 				days = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"],
@@ -65,7 +67,8 @@
 					TOP_SPACE: "ui-calendar-top-space",
 
 					SWITCH_VIEW: "ui-calendar-switch",
-					CALENDAR_VIEW: "ui-calendar-view"
+					CALENDAR_VIEW: "ui-calendar-view",
+					FOCUS: "ui-focus"
 				},
 
 				/**
@@ -107,6 +110,8 @@
 						rightArrow: null,
 						calendarView: null
 					};
+
+					BaseKeyboardSupport.call(self);
 				},
 
 				BaseWidget = ns.widget.BaseWidget,
@@ -199,6 +204,9 @@
 						if (self._fixMonth === self._todayMonth && !self.options.pastSelection) {
 							div.classList.add(classes.DISABLED);
 						}
+						if (self.isKeyboardSupport && ns.getConfig("keyboardSupport")) {
+							div.setAttribute("tabindex", "0");
+						}
 					}
 					while (leftDays != 0) {
 						div = createDayInRow(row);
@@ -230,6 +238,9 @@
 									self._selectDay = div;
 								}
 							}
+						}
+						if (self.isKeyboardSupport && ns.getConfig("keyboardSupport")) {
+							div.setAttribute("tabindex", "0");
 						}
 					}
 					leftDays = 7;
@@ -493,6 +504,12 @@
 				rightArrowElement.classList.add(classes.ARROW);
 				viewChangeElement.classList.add(classes.SWITCH_VIEW);
 
+				if (this.isKeyboardSupport && ns.getConfig("keyboardSupport")) {
+					leftArrowElement.setAttribute("tabindex", "0");
+					rightArrowElement.setAttribute("tabindex", "0");
+					viewChangeElement.setAttribute("tabindex", "0");
+				}
+
 				controllerElement.appendChild(leftArrowElement);
 				controllerElement.appendChild(rightArrowElement);
 				controllerElement.appendChild(viewChangeElement);
@@ -525,7 +542,20 @@
 				element.appendChild(controllerElement);
 				element.appendChild(viewTableElement);
 
+				if (this.isKeyboardSupport && ns.getConfig("keyboardSupport")) {
+					element.setAttribute("data-focus-lock", "true");
+					element.setAttribute("tabindex", "0");
+				}
+
 				return element;
+			};
+
+			prototype._focus = function () {
+				this.element.classList.add(classes.FOCUS);
+			};
+
+			prototype._blur = function () {
+				this.element.classList.remove(classes.FOCUS);
 			};
 
 			prototype._destroy = function () {
@@ -543,6 +573,10 @@
 				Calendar,
 				"mobile"
 			);
+
+			BaseKeyboardSupport.registerActiveSelector(".ui-calendar, .ui-calendar-arrow, .ui-calendar-switch," +
+				".ui-calendar-current-month-day, .ui-calendar-prev-month-day, .ui-calendar-next-month-day");
+
 			//>>excludeStart("tauBuildExclude", pragmas.tauBuildExclude);
 			return ns.widget.mobile.Calendar;
 		}


### PR DESCRIPTION
[Issue] https://github.com/Samsung/TAU/issues/1656
[Problem] Calendar doesn't support remote control
[Solution]
 - added base keyboard support
 - added focus css styles

[Screenshot]
![calendar](https://user-images.githubusercontent.com/29534410/113410594-14f61500-93b4-11eb-8e8b-6b111a8525d0.gif)


Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>