### PR TITLE
(build) fix for build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fast-stats": "0.0.2",
     "grunt": "^0.4",
     "grunt-auto-install": "^0.2.3",
-    "grunt-cli": "^1.3.2",
+    "grunt-cli": "1.3.2",
     "grunt-contrib-clean": "0.5.0",
     "grunt-contrib-compress": "0.13.0",
     "grunt-contrib-concat": "~0.5.0",


### PR DESCRIPTION
[Issue] n/a
[Problem] SyntaxError: Unexpected token ... in litfup package
[Solution]
 - version of grunt-cli package has been frozen to 1.3.2

Signed-off-by: Tomasz Lukawski <t.lukawski@samsung.com>